### PR TITLE
Ensure dotenv is configured before other imports

### DIFF
--- a/bin/generate_key.ts
+++ b/bin/generate_key.ts
@@ -1,8 +1,7 @@
-import * as crypto from "crypto"
-import * as dotenv from "dotenv"
-import * as keys from "../src/server/api_key"
+import "dotenv/config"
 
-dotenv.config()
+import * as crypto from "crypto"
+import * as keys from "../src/server/api_key"
 
 /* tslint:disable no-console */
 console.log("Here's a valid API key:")

--- a/src/xpc/execute_process.ts
+++ b/src/xpc/execute_process.ts
@@ -1,11 +1,10 @@
-import * as dotenv from "dotenv"
+import "dotenv/config"
 import * as winston from "winston"
 
 import { registerDebugAction } from "../actions/debug/debug"
 import "../actions/index.ts"
 import * as Hub from "../hub/index"
 
-dotenv.config()
 registerDebugAction()
 
 async function execute(jsonPayload: any) {

--- a/src/xpc/extended_execute_process.ts
+++ b/src/xpc/extended_execute_process.ts
@@ -1,11 +1,10 @@
-import * as dotenv from "dotenv"
+import "dotenv/config"
 import * as winston from "winston"
 
 import { registerDebugAction } from "../actions/debug/debug"
 import "../actions/index.ts"
 import * as Hub from "../hub/index"
 
-dotenv.config()
 registerDebugAction()
 
 async function execute(jsonPayload: any) {


### PR DESCRIPTION
I noticed this in the course of unrelated development. My new actions issue a warning to the log when they fail to register because of missing env vars. I noticed these warnings were being printed during the ProcessQueue tests. So I took a look and saw that the action files were being imported before calling `dotenv.config()`. Which means that if any actions were depending on certain env vars at import time (like mine) they would fail when executed in a separate process.

Instead I switched the imports to `import "dotenv/config"` which is the recommendation that plays best with our existing setup: https://www.npmjs.com/package/dotenv#how-do-i-use-dotenv-with-import-