### PR TITLE
fix: get all ad accounts and paginate for FB

### DIFF
--- a/src/actions/facebook/README.md
+++ b/src/actions/facebook/README.md
@@ -115,7 +115,6 @@ Selecting a delivery option opens the Scheduler for Explores and Looks. Enter a 
     > Note: Looker will need access to a minimum of 1 business account
 
 1.  Back in the **Facebook Custom Audiences** section of the Scheduler, click the **Verify credentials** button.
-1.  Select your business account from the **Choose a business** drop-down. This is the account that your ads account falls under. Typically a business account and not your personal Facebook account.
 1.  Select your ads account from the **Choose a Facebook ad account** drop-down.
 1.  Choose whether to create a new audience, append to an existing audience, or replace an existing audience. Creating a new audience or updating resets your ads to the "learning" stage. Replacing does not.
 

--- a/src/actions/facebook/facebook_custom_audiences.ts
+++ b/src/actions/facebook/facebook_custom_audiences.ts
@@ -182,4 +182,6 @@ if (process.env.FACEBOOK_CLIENT_ID
       process.env.FACEBOOK_CLIENT_SECRET,
     )
     Hub.addAction(fcma)
+} else {
+  winston.warn(`[Facebook Custom Audiences] Action not registered because required environment variables are missing.`)
 }

--- a/src/actions/facebook/lib/api.ts
+++ b/src/actions/facebook/lib/api.ts
@@ -77,37 +77,30 @@ export default class FacebookCustomAudiencesApi {
         this.accessToken = accessToken
     }
 
+    async pagingResults(url: string): Promise<any> {
+        let data: any = []
+        let hasNext = true
+
+        while (hasNext) {
+            const response = await this.apiCall("GET", url)
+            data = [...data, ...response.data]
+            if (!response.paging || !response.paging.next) {
+                hasNext = false
+            } else {
+                url = response.paging.next
+                .replace(API_BASE_URL, "")
+                .replace(/access_token=.+?&/, "")
+            }
+        }
+        return data
+    }
+
     async me(): Promise<any> {
         return this.apiCall("GET", "me")
     }
 
-    /*Sample response:
-    {
-        "businesses": {
-            "data": [
-            {
-                "id": "496949287383810",
-                "name": "Cool Guys Moving LLC"
-            },
-            {
-                "id": "104000277081747",
-                "name": "Western Analytics"
-            }
-            ],
-        }
-        "paging": ...
-        "id": "106332305032035"
-    }*/
-    async getBusinessAccountIds(): Promise<{name: string, id: string}[]> {
-        const response = await this.apiCall("GET", "me?fields=businesses")
-        const namesAndIds = response.businesses.data.map((businessMetadata: any) =>
-        ({ name: businessMetadata.name, id: businessMetadata.id }))
-        return namesAndIds
-    }
-
     /*
         Sample response:
-
         {
             "data": [
                 {
@@ -116,33 +109,48 @@ export default class FacebookCustomAudiencesApi {
                 "id": "act_114108701688636"
                 }
             ],
-            "paging": {}
+            "paging": {
+                "cursors": {
+                    "before": "abcdef123",
+                    "after": "abcdef456"
+                },
+                "previous": "https://graph.facebook.com...&before=abcdef123",
+                "next": "https://graph.facebook.com...&after=abcdef456"
+            }
         }
     */
-    async getAdAccountsForBusiness(businessId: string): Promise<{name: string, id: string}[]> {
-        const addAcountsForBusinessUrl = `${businessId}/owned_ad_accounts?fields=name,account_id`
-        const response = await this.apiCall("GET", addAcountsForBusinessUrl)
-        const namesAndIds = response.data.map((adAccountMetadata: any) =>
-        ({ name: adAccountMetadata.name, id: adAccountMetadata.account_id }))
+    async getAdAccounts(): Promise<{name: string, id: string}[]> {
+        const addAcountsUrl = `me/adaccounts?fields=name,account_id`
+        const data = await this.pagingResults(addAcountsUrl)
+        const namesAndIds = data
+            .map((adAccountMetadata: any) => ({ name: adAccountMetadata.name, id: adAccountMetadata.account_id }))
+            .sort(sortCompare)
         return namesAndIds
     }
 
     /*
         Sample response:
         {
-        "data": [
-            {
-            "name": "My new Custom Audience",
-            "id": "23837492450850533"
+            "data": [
+                {
+                "name": "My new Custom Audience",
+                "id": "23837492450850533"
+                }
+            ],
+            "paging": {
+                "cursors": {
+                    "before": "abcdef123",
+                    "after": "abcdef456"
+                },
+                "previous": "https://graph.facebook.com...&before=abcdef123",
+                "next": "https://graph.facebook.com...&after=abcdef456"
             }
-        ],
-        "paging":...
         }
     */
     async getCustomAudiences(adAccountId: string): Promise<{name: string, id: string}[]> {
         const customAudienceUrl = `act_${adAccountId}/customaudiences?fields=name`
-        const response = await this.apiCall("GET", customAudienceUrl)
-        const namesAndIds = response.data
+        const data = await this.pagingResults(customAudienceUrl)
+        const namesAndIds = data
             .map((customAudienceMetadata: any) =>
             ({name: customAudienceMetadata.name, id: customAudienceMetadata.id}))
             .sort(sortCompare)

--- a/src/actions/facebook/lib/api.ts
+++ b/src/actions/facebook/lib/api.ts
@@ -2,7 +2,7 @@ import * as gaxios from "gaxios"
 import * as winston from "winston"
 import {formatFullDate, isNullOrUndefined, sanitizeError, sortCompare} from "./util"
 
-export const API_VERSION = "v12.0"
+export const API_VERSION = "v14.0"
 export const API_BASE_URL = `https://graph.facebook.com/${API_VERSION}/`
 export const CUSTOMER_LIST_SOURCE_TYPES = {
     // Used by Facebook for unknown purposes.

--- a/src/actions/facebook/lib/executor.ts
+++ b/src/actions/facebook/lib/executor.ts
@@ -153,8 +153,8 @@ export default class FacebookCustomAudiencesExecutor {
     }
     this.operationType = operationType
 
-    if (!actionRequest.formParams.choose_business || !actionRequest.formParams.choose_ad_account) {
-      throw new Error("Cannot execute action without business id or ad account id.")
+    if (!actionRequest.formParams.choose_ad_account) {
+      throw new Error("Cannot execute action without ad account id.")
     }
     if (!actionRequest.formParams.choose_custom_audience && (
       operationType === "update_audience" || operationType === "replace_audience"

--- a/src/actions/facebook/lib/form_builder.ts
+++ b/src/actions/facebook/lib/form_builder.ts
@@ -5,33 +5,13 @@ import FacebookCustomAudiencesApi from "./api"
 export default class FacebookFormBuilder {
 
     async generateActionForm(actionRequest: Hub.ActionRequest, facebookApi: FacebookCustomAudiencesApi) {
-      let businesses: {name: string, id: string}[] = []
       let adAccounts: {name: string, id: string}[] = []
       let customAudiences: {name: string, id: string}[] = []
 
-      businesses = await facebookApi.getBusinessAccountIds()
-
-      if (actionRequest.formParams.choose_business === "reset") {
-        actionRequest.formParams = {}
-      }
+      adAccounts = await facebookApi.getAdAccounts()
 
       const form = new Hub.ActionForm()
       form.fields = [{
-        label: "Choose a business",
-        name: "choose_business",
-        description: "You can start over by choosing \"Start over\" from this list.",
-        required: true,
-        interactive: true,
-        type: "select" as "select",
-        options: [
-          {name: "reset", label: "Start over"},
-          ...(await this.generateOptionsFromNamesAndIds(businesses)),
-        ],
-      }]
-      if (actionRequest.formParams.choose_business) {
-        adAccounts = await facebookApi.getAdAccountsForBusiness(actionRequest.formParams.choose_business)
-
-        form.fields.push({
           label: "Choose a Facebook ad account",
           name: "choose_ad_account",
           required: true,
@@ -40,8 +20,7 @@ export default class FacebookFormBuilder {
           options: [
             ...(await this.generateOptionsFromNamesAndIds(adAccounts)),
           ],
-        })
-      }
+        }]
       if (actionRequest.formParams.choose_ad_account) {
         form.fields.push({
           label: "Would you like to create a new audience, update existing, or replace existing?",
@@ -93,8 +72,7 @@ export default class FacebookFormBuilder {
         if (!actionRequest.formParams.choose_ad_account) {
           throw new Error("Cannot obtain audience list without an ad account selected")
         }
-        customAudiences = await facebookApi.getCustomAudiences(
-        actionRequest.formParams.choose_ad_account)
+        customAudiences = await facebookApi.getCustomAudiences(actionRequest.formParams.choose_ad_account)
 
         const audienceActionType = (
           actionRequest.formParams.choose_create_update_replace === "update_audience") ?


### PR DESCRIPTION
Remove business account form field in place of request for all ad accounts. Also paginate results for ad accounts and custom audiences