### PR TITLE
Sanitize apostrophe's to Google Sheets overwrite

### DIFF
--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -105,6 +105,7 @@ export class GoogleSheetsAction extends GoogleDriveAction {
     async sendOverwriteData(filename: string, request: Hub.ActionRequest, drive: Drive, sheet: Sheet) {
         const parents = request.formParams.folder ? [request.formParams.folder] : undefined
 
+        filename = this.sanitizeFilename(filename)
         const options: any = {
             q: `name = '${filename}' and '${parents}' in parents and trashed=false`,
             fields: "files",
@@ -293,6 +294,10 @@ export class GoogleSheetsAction extends GoogleDriveAction {
         }).catch((e: any) => {
             throw e
         })
+    }
+
+    sanitizeFilename(filename: string) {
+        return filename.split("'").join("\'")
     }
 
     async flush(buffer: sheets_v4.Schema$BatchUpdateSpreadsheetRequest,

--- a/src/actions/google/drive/sheets/test_google_sheets.ts
+++ b/src/actions/google/drive/sheets/test_google_sheets.ts
@@ -396,6 +396,13 @@ describe(`${action.constructor.name} unit tests`, () => {
       })
     })
 
+    describe("sanitizeFilename", () => {
+      it("will sanitize apostrophe in filename", () => {
+        const filename = "Barbara'sFile.csv"
+        chai.expect(action.sanitizeFilename(filename)).to.equal("Barbara\'sFile.csv")
+      })
+    })
+
     describe("flush", () => {
       it("will retry if a 429 code is received", (done) => {
         const retrySpy = sinon.spy()


### PR DESCRIPTION
Will enable filenames such as `Somebody'sFIle.csv` to be safely passed into a query param for the Drive API