### PR TITLE
Update to Facebook Graph API v16

### DIFF
--- a/src/actions/facebook/lib/api.ts
+++ b/src/actions/facebook/lib/api.ts
@@ -2,7 +2,7 @@ import * as gaxios from "gaxios"
 import * as winston from "winston"
 import {formatFullDate, isNullOrUndefined, sanitizeError, sortCompare} from "./util"
 
-export const API_VERSION = "v14.0"
+export const API_VERSION = "v16.0"
 export const API_BASE_URL = `https://graph.facebook.com/${API_VERSION}/`
 export const CUSTOMER_LIST_SOURCE_TYPES = {
     // Used by Facebook for unknown purposes.


### PR DESCRIPTION
Graph API v14 is deprecated April 25th. Upgrading to v15 and v16 does not impact any of the endpoints that we use in this action.