### PR TITLE
Add slack postMessage for new upload path

### DIFF
--- a/lib/actions/facebook/lib/api.d.ts
+++ b/lib/actions/facebook/lib/api.d.ts
@@ -1,4 +1,4 @@
-export declare const API_VERSION = "v14.0";
+export declare const API_VERSION = "v16.0";
 export declare const API_BASE_URL: string;
 export declare const CUSTOMER_LIST_SOURCE_TYPES: {
     USER_PROVIDED_ONLY: string;

--- a/lib/actions/facebook/lib/api.js
+++ b/lib/actions/facebook/lib/api.js
@@ -13,7 +13,7 @@ exports.validFacebookHashCombinations = exports.CUSTOMER_LIST_SOURCE_TYPES = exp
 const gaxios = require("gaxios");
 const winston = require("winston");
 const util_1 = require("./util");
-exports.API_VERSION = "v14.0";
+exports.API_VERSION = "v16.0";
 exports.API_BASE_URL = `https://graph.facebook.com/${exports.API_VERSION}/`;
 exports.CUSTOMER_LIST_SOURCE_TYPES = {
     // Used by Facebook for unknown purposes.

--- a/lib/actions/slack/utils.js
+++ b/lib/actions/slack/utils.js
@@ -125,6 +125,9 @@ const handleExecute = (request, slack) => __awaiter(void 0, void 0, void 0, func
                         const buffer = Buffer.concat(buffs);
                         const comment = request.formParams.initial_comment ? request.formParams.initial_comment : "";
                         winston.info(`Attempting to send ${buffer.byteLength} bytes to Slack`, { webhookId });
+                        // Unfortunately UploadV2 does not provide a way to upload files
+                        // to user tokens which are common in Looker schedules
+                        // (UXXXXXXX)
                         if (isUserToken || forceV1Upload) {
                             winston.info(`V1 Upload of file`, { webhookId });
                             yield slack.files.upload({
@@ -154,10 +157,20 @@ const handleExecute = (request, slack) => __awaiter(void 0, void 0, void 0, func
                                         id: res.file_id ? res.file_id : "",
                                     }],
                                 channel_id: request.formParams.channel,
-                                initial_comment: comment,
                             }).catch((e) => {
                                 reject(e);
                             });
+                            // Workaround for regression in V2 upload, the initial
+                            // comment does not support markdown formatting, breaking
+                            // customer links
+                            if (comment !== "") {
+                                yield slack.chat.postMessage({
+                                    channel: request.formParams.channel,
+                                    text: comment,
+                                }).catch((e) => {
+                                    reject(e);
+                                });
+                            }
                         }
                         resolve();
                     }));


### PR DESCRIPTION
Added new postMessage call for file upload V2 for Slack as it does not support markdown formatted messages

Facebook lib/ update is due to error in previous PR which did not update the lib/ directory