### PR TITLE
We should capture all errors and log it to be able to debug error instances

### DIFF
--- a/src/hub/action_request.ts
+++ b/src/hub/action_request.ts
@@ -252,6 +252,10 @@ export class ActionRequest {
     })
 
     const results = await Promise.all([returnPromise, streamPromise])
+        .catch((err: any) => {
+          winston.error(`Error caught awaiting for results. Error: ${err.toString()}`, this.logInfo)
+          throw err
+        })
     return results[0]
   }
 


### PR DESCRIPTION
Promise.all() should be captured and logged to ensure we do not miss an occasion where an error is not properly returned to the Looker instance