### PR TITLE
Update Slack to not use retries if the request is for an execute

### DIFF
--- a/lib/actions/slack/legacy_slack/slack.js
+++ b/lib/actions/slack/legacy_slack/slack.js
@@ -36,7 +36,7 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
     }
     execute(request) {
         return __awaiter(this, void 0, void 0, function* () {
-            return yield (0, utils_1.handleExecute)(request, this.slackClientFromRequest(request));
+            return yield (0, utils_1.handleExecute)(request, this.slackClientFromRequest(request, true));
         });
     }
     form(request) {
@@ -53,8 +53,13 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
             return form;
         });
     }
-    slackClientFromRequest(request) {
-        return new web_api_1.WebClient(request.params.slack_api_token);
+    slackClientFromRequest(request, disableRetries = false) {
+        if (disableRetries) {
+            return new web_api_1.WebClient(request.params.slack_api_token, { retryConfig: { retries: 0 } });
+        }
+        else {
+            return new web_api_1.WebClient(request.params.slack_api_token);
+        }
     }
 }
 exports.SlackAttachmentAction = SlackAttachmentAction;

--- a/lib/actions/slack/slack.js
+++ b/lib/actions/slack/slack.js
@@ -39,7 +39,7 @@ class SlackAction extends Hub.DelegateOAuthAction {
     }
     execute(request) {
         return __awaiter(this, void 0, void 0, function* () {
-            const clientManager = new slack_client_manager_1.SlackClientManager(request);
+            const clientManager = new slack_client_manager_1.SlackClientManager(request, false);
             const selectedClient = clientManager.getSelectedClient();
             if (!selectedClient) {
                 return new Hub.ActionResponse({ success: false, message: AUTH_MESSAGE });
@@ -51,7 +51,7 @@ class SlackAction extends Hub.DelegateOAuthAction {
     }
     form(request) {
         return __awaiter(this, void 0, void 0, function* () {
-            const clientManager = new slack_client_manager_1.SlackClientManager(request);
+            const clientManager = new slack_client_manager_1.SlackClientManager(request, true);
             if (!clientManager.hasAnyClients()) {
                 return this.loginForm(request);
             }

--- a/lib/actions/slack/slack_client_manager.d.ts
+++ b/lib/actions/slack/slack_client_manager.d.ts
@@ -3,11 +3,11 @@ import * as Hub from "../../hub";
 export declare const PLACEHOLDER_WORKSPACE = "any";
 export declare const MULTI_WORKSPACE_SUPPORTED_VERSION = "7.3.0";
 export declare const isSupportMultiWorkspaces: (request: Hub.ActionRequest) => boolean | "" | null;
-export declare const makeSlackClient: (token: string) => WebClient;
+export declare const makeSlackClient: (token: string, disableRetries?: boolean) => WebClient;
 export declare class SlackClientManager {
     private selectedInstallId;
     private clients;
-    constructor(request: Hub.ActionRequest);
+    constructor(request: Hub.ActionRequest, isForm?: boolean);
     hasAnyClients: () => boolean;
     getClients: () => WebClient[];
     hasSelectedClient: () => boolean;

--- a/lib/actions/slack/slack_client_manager.js
+++ b/lib/actions/slack/slack_client_manager.js
@@ -8,10 +8,17 @@ exports.PLACEHOLDER_WORKSPACE = "any";
 exports.MULTI_WORKSPACE_SUPPORTED_VERSION = "7.3.0";
 const isSupportMultiWorkspaces = (request) => request.lookerVersion && semver.gte(request.lookerVersion, exports.MULTI_WORKSPACE_SUPPORTED_VERSION);
 exports.isSupportMultiWorkspaces = isSupportMultiWorkspaces;
-const makeSlackClient = (token) => new web_api_1.WebClient(token);
+const makeSlackClient = (token, disableRetries = false) => {
+    if (disableRetries) {
+        return new web_api_1.WebClient(token, { retryConfig: { retries: 0 } });
+    }
+    else {
+        return new web_api_1.WebClient(token);
+    }
+};
 exports.makeSlackClient = makeSlackClient;
 class SlackClientManager {
-    constructor(request) {
+    constructor(request, isForm = false) {
         this.hasAnyClients = () => Object.entries(this.clients).length > 0;
         this.getClients = () => Object.values(this.clients);
         this.hasSelectedClient = () => !!this.selectedInstallId;
@@ -38,7 +45,7 @@ class SlackClientManager {
                     .reduce((accumulator, stateJsonItem) => {
                     const ws = stateJsonItem.install_id;
                     if (stateJsonItem.token) {
-                        accumulator[ws] = (0, exports.makeSlackClient)(stateJsonItem.token);
+                        accumulator[ws] = (0, exports.makeSlackClient)(stateJsonItem.token, isForm);
                     }
                     return accumulator;
                 }, {});
@@ -56,7 +63,7 @@ class SlackClientManager {
             }
             else {
                 this.selectedInstallId = exports.PLACEHOLDER_WORKSPACE;
-                this.clients = { [exports.PLACEHOLDER_WORKSPACE]: (0, exports.makeSlackClient)(stateJson) };
+                this.clients = { [exports.PLACEHOLDER_WORKSPACE]: (0, exports.makeSlackClient)(stateJson, isForm) };
             }
         }
     }

--- a/lib/hub/action_request.js
+++ b/lib/hub/action_request.js
@@ -186,7 +186,11 @@ class ActionRequest {
                     }
                 }
             });
-            const results = yield Promise.all([returnPromise, streamPromise]);
+            const results = yield Promise.all([returnPromise, streamPromise])
+                .catch((err) => {
+                winston.error(`Error caught awaiting for results. Error: ${err.toString()}`, this.logInfo);
+                throw err;
+            });
             return results[0];
         });
     }

--- a/src/actions/slack/legacy_slack/slack.ts
+++ b/src/actions/slack/legacy_slack/slack.ts
@@ -24,7 +24,7 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
   usesStreaming = false
 
   async execute(request: Hub.ActionRequest) {
-    return await handleExecute(request, this.slackClientFromRequest(request))
+    return await handleExecute(request, this.slackClientFromRequest(request, true))
   }
 
   async form(request: Hub.ActionRequest) {
@@ -41,8 +41,12 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
     return form
   }
 
-  private slackClientFromRequest(request: Hub.ActionRequest) {
-    return new WebClient(request.params.slack_api_token!)
+  private slackClientFromRequest(request: Hub.ActionRequest, disableRetries = false) {
+    if (disableRetries) {
+      return new WebClient(request.params.slack_api_token!, {retryConfig: {retries: 0}})
+    } else {
+      return new WebClient(request.params.slack_api_token!)
+    }
   }
 
 }

--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -35,7 +35,7 @@ export class SlackAction extends Hub.DelegateOAuthAction {
   usesStreaming = true
 
   async execute(request: Hub.ActionRequest) {
-    const clientManager = new SlackClientManager(request)
+    const clientManager = new SlackClientManager(request, false)
     const selectedClient = clientManager.getSelectedClient()
     if (!selectedClient) {
       return new Hub.ActionResponse({success: false, message: AUTH_MESSAGE})
@@ -45,7 +45,7 @@ export class SlackAction extends Hub.DelegateOAuthAction {
   }
 
   async form(request: Hub.ActionRequest) {
-    const clientManager = new SlackClientManager(request)
+    const clientManager = new SlackClientManager(request, true)
     if (!clientManager.hasAnyClients()) {
       return this.loginForm(request)
     }

--- a/src/actions/slack/slack_client_manager.ts
+++ b/src/actions/slack/slack_client_manager.ts
@@ -15,13 +15,19 @@ export const MULTI_WORKSPACE_SUPPORTED_VERSION = "7.3.0"
 export const isSupportMultiWorkspaces = (request: Hub.ActionRequest) =>
     request.lookerVersion && semver.gte(request.lookerVersion, MULTI_WORKSPACE_SUPPORTED_VERSION)
 
-export const makeSlackClient = (token: string): WebClient => new WebClient(token)
+export const makeSlackClient = (token: string, disableRetries = false): WebClient => {
+    if (disableRetries) {
+        return new WebClient(token, {retryConfig: {retries: 0}})
+    } else {
+        return new WebClient(token)
+    }
+}
 
 export class SlackClientManager {
     private selectedInstallId: string | undefined
     private clients: { [key: string]: WebClient }
 
-    constructor(request: Hub.ActionRequest) {
+    constructor(request: Hub.ActionRequest, isForm = false) {
         const stateJson = request.params.state_json
 
         if (!stateJson) {
@@ -42,7 +48,7 @@ export class SlackClientManager {
                     .reduce((accumulator, stateJsonItem) => {
                         const ws = stateJsonItem.install_id
                         if (stateJsonItem.token) {
-                            accumulator[ws] = makeSlackClient(stateJsonItem.token)
+                            accumulator[ws] = makeSlackClient(stateJsonItem.token, isForm)
                         }
                         return accumulator
                     }, {} as { [key: string]: WebClient })
@@ -59,7 +65,7 @@ export class SlackClientManager {
                 }
             } else {
                 this.selectedInstallId = PLACEHOLDER_WORKSPACE
-                this.clients = {[PLACEHOLDER_WORKSPACE]: makeSlackClient(stateJson)}
+                this.clients = {[PLACEHOLDER_WORKSPACE]: makeSlackClient(stateJson, isForm)}
             }
         }
     }


### PR DESCRIPTION
Slack should not be retrying its file uploads as it is causing many duplicate sends. Only disable WebClient retries if the request is for an execute.

https://slack.dev/node-slack-sdk/web-api