### PR TITLE
Isolate Slack to its own process to prevent errors from spreading to other actions

### DIFF
--- a/lib/actions/slack/legacy_slack/slack.d.ts
+++ b/lib/actions/slack/legacy_slack/slack.d.ts
@@ -14,6 +14,7 @@ export declare class SlackAttachmentAction extends Hub.Action {
         sensitive: boolean;
     }[];
     usesStreaming: boolean;
+    executeInOwnProcess: boolean;
     execute(request: Hub.ActionRequest): Promise<Hub.ActionResponse>;
     form(request: Hub.ActionRequest): Promise<Hub.ActionForm>;
     private slackClientFromRequest;

--- a/lib/actions/slack/legacy_slack/slack.js
+++ b/lib/actions/slack/legacy_slack/slack.js
@@ -33,6 +33,7 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
                 sensitive: true,
             }];
         this.usesStreaming = false;
+        this.executeInOwnProcess = true;
     }
     execute(request) {
         return __awaiter(this, void 0, void 0, function* () {

--- a/lib/actions/slack/slack.d.ts
+++ b/lib/actions/slack/slack.d.ts
@@ -17,6 +17,7 @@ export declare class SlackAction extends Hub.DelegateOAuthAction {
     }[];
     minimumSupportedLookerVersion: string;
     usesStreaming: boolean;
+    executeInOwnProcess: boolean;
     execute(request: Hub.ActionRequest): Promise<Hub.ActionResponse>;
     form(request: Hub.ActionRequest): Promise<Hub.ActionForm>;
     loginForm(request: Hub.ActionRequest, form?: Hub.ActionForm): Promise<Hub.ActionForm>;

--- a/lib/actions/slack/slack.js
+++ b/lib/actions/slack/slack.js
@@ -36,6 +36,7 @@ class SlackAction extends Hub.DelegateOAuthAction {
             }];
         this.minimumSupportedLookerVersion = "6.23.0";
         this.usesStreaming = true;
+        this.executeInOwnProcess = true;
     }
     execute(request) {
         return __awaiter(this, void 0, void 0, function* () {

--- a/src/actions/slack/legacy_slack/slack.ts
+++ b/src/actions/slack/legacy_slack/slack.ts
@@ -22,6 +22,7 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
     sensitive: true,
   }]
   usesStreaming = false
+  executeInOwnProcess = true
 
   async execute(request: Hub.ActionRequest) {
     return await handleExecute(request, this.slackClientFromRequest(request, true))

--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -33,6 +33,7 @@ export class SlackAction extends Hub.DelegateOAuthAction {
   }]
   minimumSupportedLookerVersion = "6.23.0"
   usesStreaming = true
+  executeInOwnProcess = true
 
   async execute(request: Hub.ActionRequest) {
     const clientManager = new SlackClientManager(request, true)

--- a/src/actions/slack/test_slack.ts
+++ b/src/actions/slack/test_slack.ts
@@ -8,6 +8,7 @@ import {isSupportMultiWorkspaces, MULTI_WORKSPACE_SUPPORTED_VERSION} from "./sla
 import * as utils from "./utils"
 
 const action = new SlackAction()
+action.executeInOwnProcess = false
 
 // @ts-ignore
 const stubSlackClient = (fn: () => void) => sinon.stub(SlackClientManager, "makeSlackClient").callsFake(fn)


### PR DESCRIPTION
Slack platform_errors can currently crash a Node process. This PR moves the action to execute in its own process, and further configuration can isolate the action to a queue that will not affect other actions .