### PR TITLE
Add response formatting to errors in heavy actions

### DIFF
--- a/lib/actions/google/drive/sheets/google_sheets.js
+++ b/lib/actions/google/drive/sheets/google_sheets.js
@@ -65,7 +65,7 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                 }
                 catch (e) {
                     this.sanitizeGaxiosError(e);
-                    winston.debug(`Failed execute for Google Sheets. Error: ${e.toString()}`, { webhookId: request.webhookId });
+                    winston.error(`Failed execute for Google Sheets. Error: ${e.toString()}`, { webhookId: request.webhookId });
                     resp.success = false;
                     resp.message = e.toString();
                 }
@@ -178,7 +178,7 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                         yield this.clearSheet(spreadsheetId, sheet, sheetId);
                         csvparser.on("data", (line) => {
                             if (rowCount > maxPossibleRows) {
-                                throw `Cannot send more than ${maxPossibleRows} without exceeding limit of 5 million cells in Google Sheets`;
+                                reject(`Cannot send more than ${maxPossibleRows} without exceeding limit of 5 million cells in Google Sheets`);
                             }
                             const rowIndex = rowCount++;
                             // Sanitize line data and properly encapsulate string formatting for CSV lines

--- a/lib/hub/action.js
+++ b/lib/hub/action.js
@@ -81,8 +81,11 @@ class Action {
                         Object.assign(actionResponse, response);
                         resolve(actionResponse);
                     }).catch((err) => {
-                        winston.error(JSON.stringify(err));
-                        reject(err);
+                        winston.error(`${JSON.stringify(err)}`, { webhookId: request.webhookId });
+                        const response = new _1.ActionResponse();
+                        response.success = false;
+                        response.message = JSON.stringify(err);
+                        reject(response);
                     });
                 });
             }

--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -57,7 +57,7 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                 }
             } catch (e: any) {
                 this.sanitizeGaxiosError(e)
-                winston.debug(`Failed execute for Google Sheets. Error: ${e.toString()}`,
+                winston.error(`Failed execute for Google Sheets. Error: ${e.toString()}`,
                     {webhookId: request.webhookId})
                 resp.success = false
                 resp.message = e.toString()
@@ -174,7 +174,7 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                     await this.clearSheet(spreadsheetId, sheet, sheetId)
                     csvparser.on("data", (line: any) => {
                         if (rowCount > maxPossibleRows) {
-                            throw `Cannot send more than ${maxPossibleRows} without exceeding limit of 5 million cells in Google Sheets`
+                            reject(`Cannot send more than ${maxPossibleRows} without exceeding limit of 5 million cells in Google Sheets`)
                         }
                         const rowIndex: number = rowCount++
                         // Sanitize line data and properly encapsulate string formatting for CSV lines

--- a/src/hub/action.ts
+++ b/src/hub/action.ts
@@ -123,13 +123,16 @@ export abstract class Action {
       request.actionId = this.name
       winston.info(`Execute Action Enqueued. Queue length: ${queue.queue.size}`, {webhookId: request.webhookId})
       return new Promise<ActionResponse>((resolve, reject) => {
-        queue.run(JSON.stringify(request)).then((response: string) => {
+        queue.run(JSON.stringify(request)).then((response: any) => {
           const actionResponse = new ActionResponse()
           Object.assign(actionResponse, response)
           resolve(actionResponse)
         }).catch((err) => {
-          winston.error(JSON.stringify(err))
-          reject(err)
+          winston.error(`${JSON.stringify(err)}`, {webhookId: request.webhookId})
+          const response = new ActionResponse()
+          response.success = false
+          response.message = JSON.stringify(err)
+          reject(response)
         })
       })
     } else {


### PR DESCRIPTION
Add proper response formatting to responses back to Looker to ensure failures are marked as failures. Also reject instead of throw in Google Sheets