### PR TITLE
User tokens can start with a 'W' as well as a 'U'

### DIFF
--- a/src/actions/slack/test_utils.ts
+++ b/src/actions/slack/test_utils.ts
@@ -350,6 +350,24 @@ describe(`slack/utils unit tests`, () => {
             })
         })
 
+        it("uses V1 if channel is a User token with a W prefix", () => {
+            const request = new Hub.ActionRequest()
+            request.type = Hub.ActionType.Query
+            request.formParams = {
+                channel: "W12345",
+                initial_comment: "mycomment",
+            }
+            request.attachment = {
+                dataBuffer: Buffer.from("1,2,3,4", "utf8"),
+                fileExtension: "csv",
+            }
+            return expectSlackMatchV1(request, {
+                channels: request.formParams.channel,
+                initial_comment: request.formParams.initial_comment,
+                file: Buffer.from("1,2,3,4", "utf8"),
+            })
+        })
+
         it("returns failure on slack files.upload error", (done) => {
             const request = new Hub.ActionRequest()
             const fileId = "1234ABCDX"

--- a/src/actions/slack/utils.ts
+++ b/src/actions/slack/utils.ts
@@ -107,7 +107,7 @@ export const handleExecute = async (request: Hub.ActionRequest, slack: WebClient
 
     let response = new Hub.ActionResponse({success: true})
     try {
-        const isUserToken = request.formParams.channel.startsWith("U")
+        const isUserToken = request.formParams.channel.startsWith("U") || request.formParams.channel.startsWith("W")
         const forceV1Upload = process.env.FORCE_V1_UPLOAD
         if (!request.empty()) {
             const buffs: any[] = []


### PR DESCRIPTION
Add a check for the 'W' prefix. All user uploads must use the older upload path