### PR TITLE
Add default ability to manually set target channel or user for Slack action

### DIFF
--- a/lib/actions/slack/legacy_slack/slack.js
+++ b/lib/actions/slack/legacy_slack/slack.js
@@ -12,7 +12,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.SlackAttachmentAction = void 0;
 const Hub = require("../../../hub");
 const web_api_1 = require("@slack/web-api");
-const _ = require("lodash");
 const utils_1 = require("../utils");
 class SlackAttachmentAction extends Hub.Action {
     constructor() {
@@ -43,8 +42,7 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
     form(request) {
         return __awaiter(this, void 0, void 0, function* () {
             const form = new Hub.ActionForm();
-            const channelType = _.isNil(request.formParams.channelType) || request.formParams.channelType === "channels"
-                ? "channels" : "users";
+            const channelType = request.formParams.channelType ? request.formParams.channelType : "manual";
             try {
                 form.fields = yield (0, utils_1.getDisplayedFormFields)(this.slackClientFromRequest(request), channelType);
             }

--- a/lib/actions/slack/slack.js
+++ b/lib/actions/slack/slack.js
@@ -10,7 +10,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SlackAction = void 0;
-const _ = require("lodash");
 const winston = require("winston");
 const Hub = require("../../hub");
 const slack_client_manager_1 = require("./slack_client_manager");
@@ -84,8 +83,7 @@ class SlackAction extends Hub.DelegateOAuthAction {
             if (!client) {
                 return this.loginForm(request, form);
             }
-            const channelType = _.isNil(request.formParams.channelType) || request.formParams.channelType === "channels"
-                ? "channels" : "users";
+            const channelType = request.formParams.channelType ? request.formParams.channelType : "manual";
             try {
                 form.fields = form.fields.concat(yield (0, utils_1.getDisplayedFormFields)(client, channelType));
             }

--- a/lib/actions/slack/utils.js
+++ b/lib/actions/slack/utils.js
@@ -62,41 +62,60 @@ const usableDMs = (slack) => __awaiter(void 0, void 0, void 0, function* () {
     return users.map((user) => ({ id: user.id, label: `@${user.name}` }));
 });
 const getDisplayedFormFields = (slack, channelType) => __awaiter(void 0, void 0, void 0, function* () {
-    let channels;
+    let channels = [];
+    let manualId = false;
     if (channelType === "channels") {
         channels = yield _usableChannels(slack);
     }
-    else {
+    else if (channelType === "users") {
         channels = yield usableDMs(slack);
     }
-    channels.sort((a, b) => ((a.label < b.label) ? -1 : 1));
-    return [
+    else {
+        manualId = true;
+    }
+    const response = [
         {
             description: "Type of destination to fetch",
             label: "Channel Type",
             name: "channelType",
             options: [{ name: "channels", label: "Channels" }, { name: "users", label: "Users" }],
             type: "select",
-            default: "channels",
             interactive: true,
         },
-        {
+    ];
+    // If this is the first load then let the user add a manual ID to send to Slack
+    if (manualId) {
+        response.push({
+            description: "Slack channel id",
+            label: "Share In",
+            name: "channel",
+            type: "string",
+        });
+        // If the user selected channels or users, send a sorted list of channels
+    }
+    else {
+        channels.sort((a, b) => ((a.label < b.label) ? -1 : 1));
+        response.push({
             description: "Name of the Slack channel you would like to post to.",
             label: "Share In",
             name: "channel",
             options: channels.map((channel) => ({ name: channel.id, label: channel.label })),
             required: true,
             type: "select",
-        }, {
-            label: "Comment",
-            type: "string",
-            name: "initial_comment",
-        }, {
-            label: "Filename",
-            name: "filename",
-            type: "string",
-        },
-    ];
+        });
+    }
+    // Always allow comment and filename
+    response.push({
+        label: "Comment",
+        type: "string",
+        name: "initial_comment",
+    });
+    response.push({
+        label: "Filename",
+        name: "filename",
+        type: "string",
+    });
+    return response;
 });
 exports.getDisplayedFormFields = getDisplayedFormFields;
 const handleExecute = (request, slack) => __awaiter(void 0, void 0, void 0, function* () {
@@ -107,7 +126,7 @@ const handleExecute = (request, slack) => __awaiter(void 0, void 0, void 0, func
     const fileName = request.formParams.filename ? request.completeFilename() : request.suggestedFilename();
     let response = new Hub.ActionResponse({ success: true });
     try {
-        const isUserToken = request.formParams.channel.startsWith("U");
+        const isUserToken = request.formParams.channel.startsWith("U") || request.formParams.channel.startsWith("W");
         const forceV1Upload = process.env.FORCE_V1_UPLOAD;
         if (!request.empty()) {
             const buffs = [];

--- a/lib/actions/slack/utils.js
+++ b/lib/actions/slack/utils.js
@@ -78,7 +78,12 @@ const getDisplayedFormFields = (slack, channelType) => __awaiter(void 0, void 0,
             description: "Type of destination to fetch",
             label: "Channel Type",
             name: "channelType",
-            options: [{ name: "channels", label: "Channels" }, { name: "users", label: "Users" }],
+            options: [
+                { name: "manual", label: "Manual Channel ID" },
+                { name: "channels", label: "Channels" },
+                { name: "users", label: "Users" },
+            ],
+            default: "manual",
             type: "select",
             interactive: true,
         },
@@ -86,8 +91,8 @@ const getDisplayedFormFields = (slack, channelType) => __awaiter(void 0, void 0,
     // If this is the first load then let the user add a manual ID to send to Slack
     if (manualId) {
         response.push({
-            description: "Slack channel id",
-            label: "Share In",
+            description: "Slack channel or user id",
+            label: "Channel or User ID",
             name: "channel",
             type: "string",
         });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "generate-api-key": "./node_modules/.bin/ts-node ./bin/generate_key.ts",
     "copy-api-types": "./node_modules/.bin/ts-node ./bin/copy_api_types.ts",
     "build": "rm -rf lib; ./node_modules/.bin/tsc -d -p tsconfig.npm.json",
-    "dev": "./node_modules/.bin/nodemon --exec ./node_modules/.bin/ts-node --async-stack-traces --no-cache --type-check -- ./src/boot.ts",
+    "dev": "./node_modules/.bin/nodemon --exec ./node_modules/.bin/ts-node --type-check -- ./src/boot.ts",
     "debug": "./node_modules/.bin/nodemon --exec node --inspect --trace-warnings -r ./node_modules/ts-node/register -- ./src/boot.ts",
     "debug-trace": "./node_modules/.bin/nodemon --exec node --inspect --trace-sync-io -r ./node_modules/ts-node/register -- ./src/boot.ts",
     "test-dev": "./node_modules/.bin/nodemon --exec \"yarn test || true\"",

--- a/src/actions/slack/legacy_slack/slack.ts
+++ b/src/actions/slack/legacy_slack/slack.ts
@@ -29,7 +29,7 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
 
   async form(request: Hub.ActionRequest) {
     const form = new Hub.ActionForm()
-    const channelType = request.formParams.channelType || "manual"
+    const channelType = request.formParams.channelType ? request.formParams.channelType : "manual"
     try {
       form.fields = await getDisplayedFormFields(this.slackClientFromRequest(request), channelType)
     } catch (e: any) {

--- a/src/actions/slack/legacy_slack/slack.ts
+++ b/src/actions/slack/legacy_slack/slack.ts
@@ -1,7 +1,6 @@
 import * as Hub from "../../../hub"
 
 import {WebClient} from "@slack/web-api"
-import _ = require("lodash")
 import {displayError, getDisplayedFormFields, handleExecute} from "../utils"
 
 export class SlackAttachmentAction extends Hub.Action {
@@ -30,9 +29,7 @@ https://github.com/looker/actions/blob/master/src/actions/slack/legacy_slack/REA
 
   async form(request: Hub.ActionRequest) {
     const form = new Hub.ActionForm()
-    const channelType = _.isNil(request.formParams.channelType) || request.formParams.channelType === "channels"
-        ? "channels" : "users"
-
+    const channelType = request.formParams.channelType || "manual"
     try {
       form.fields = await getDisplayedFormFields(this.slackClientFromRequest(request), channelType)
     } catch (e: any) {

--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -1,6 +1,5 @@
 import {WebClient} from "@slack/web-api"
 import {WebAPICallResult} from "@slack/web-api/dist/WebClient"
-import _ = require("lodash")
 import * as winston from "winston"
 import * as Hub from "../../hub"
 import {isSupportMultiWorkspaces, SlackClientManager} from "./slack_client_manager"
@@ -84,8 +83,7 @@ export class SlackAction extends Hub.DelegateOAuthAction {
       return this.loginForm(request, form)
     }
 
-    const channelType = _.isNil(request.formParams.channelType) || request.formParams.channelType === "channels"
-        ? "channels" : "users"
+    const channelType =  request.formParams.channelType || "manual"
 
     try {
       form.fields = form.fields.concat(await getDisplayedFormFields(client, channelType))

--- a/src/actions/slack/slack.ts
+++ b/src/actions/slack/slack.ts
@@ -83,7 +83,7 @@ export class SlackAction extends Hub.DelegateOAuthAction {
       return this.loginForm(request, form)
     }
 
-    const channelType =  request.formParams.channelType || "manual"
+    const channelType = request.formParams.channelType ? request.formParams.channelType : "manual"
 
     try {
       form.fields = form.fields.concat(await getDisplayedFormFields(client, channelType))

--- a/src/actions/slack/test_utils.ts
+++ b/src/actions/slack/test_utils.ts
@@ -250,7 +250,7 @@ describe(`slack/utils unit tests`, () => {
             ]).and.notify(done)
         })
 
-        it("returns correct users", (done) => {
+        it("returns form with manual enabled", (done) => {
             const slackClient = new WebClient("token")
             const result = getDisplayedFormFields(slackClient, "manual")
             chai.expect(result).to.eventually.deep.equal([

--- a/src/actions/slack/test_utils.ts
+++ b/src/actions/slack/test_utils.ts
@@ -138,9 +138,13 @@ describe(`slack/utils unit tests`, () => {
                     description: "Type of destination to fetch",
                     label: "Channel Type",
                     name: "channelType",
-                    options: [{name: "channels", label: "Channels"}, {name: "users", label: "Users"}],
+                    options: [
+                        {name: "manual", label: "Manual Channel ID"},
+                        {name: "channels", label: "Channels"},
+                        {name: "users", label: "Users"},
+                    ],
                     type: "select",
-                    default: "channels",
+                    default: "manual",
                     interactive: true,
                 },
                 {
@@ -214,9 +218,13 @@ describe(`slack/utils unit tests`, () => {
                     description: "Type of destination to fetch",
                     label: "Channel Type",
                     name: "channelType",
-                    options: [{name: "channels", label: "Channels"}, {name: "users", label: "Users"}],
+                    options: [
+                        {name: "manual", label: "Manual Channel ID"},
+                        {name: "channels", label: "Channels"},
+                        {name: "users", label: "Users"},
+                    ],
                     type: "select",
-                    default: "channels",
+                    default: "manual",
                     interactive: true,
                 },
                 {
@@ -230,6 +238,40 @@ describe(`slack/utils unit tests`, () => {
                         {name: "10", label: "@Z"}],
                     required: true,
                     type: "select",
+                }, {
+                    label: "Comment",
+                    type: "string",
+                    name: "initial_comment",
+                }, {
+                    label: "Filename",
+                    name: "filename",
+                    type: "string",
+                },
+            ]).and.notify(done)
+        })
+
+        it("returns correct users", (done) => {
+            const slackClient = new WebClient("token")
+            const result = getDisplayedFormFields(slackClient, "manual")
+            chai.expect(result).to.eventually.deep.equal([
+                {
+                    description: "Type of destination to fetch",
+                    label: "Channel Type",
+                    name: "channelType",
+                    options: [
+                        {name: "manual", label: "Manual Channel ID"},
+                        {name: "channels", label: "Channels"},
+                        {name: "users", label: "Users"},
+                    ],
+                    type: "select",
+                    default: "manual",
+                    interactive: true,
+                },
+                {
+                    description: "Slack channel or user id",
+                    label: "Channel or User ID",
+                    name: "channel",
+                    type: "string",
                 }, {
                     label: "Comment",
                     type: "string",

--- a/src/actions/slack/utils.ts
+++ b/src/actions/slack/utils.ts
@@ -75,7 +75,12 @@ export const getDisplayedFormFields = async (slack: WebClient, channelType: stri
             description: "Type of destination to fetch",
             label: "Channel Type",
             name: "channelType",
-            options: [{name: "channels", label: "Channels"}, {name: "users", label: "Users"}],
+            options: [
+                {name: "manual", label: "Manual Channel ID"},
+                {name: "channels", label: "Channels"},
+                {name: "users", label: "Users"},
+            ],
+            default: "manual",
             type: "select",
             interactive: true,
         },
@@ -83,8 +88,8 @@ export const getDisplayedFormFields = async (slack: WebClient, channelType: stri
     // If this is the first load then let the user add a manual ID to send to Slack
     if (manualId) {
         response.push({
-            description: "Slack channel id",
-            label: "Share In",
+            description: "Slack channel or user id",
+            label: "Channel or User ID",
             name: "channel",
             type: "string",
         })
@@ -93,7 +98,7 @@ export const getDisplayedFormFields = async (slack: WebClient, channelType: stri
         channels.sort((a, b) => ((a.label < b.label) ? -1 : 1 ))
         response.push({
             description: "Name of the Slack channel you would like to post to.",
-                label: "Share In",
+            label: "Share In",
             name: "channel",
             options: channels.map((channel) => ({ name: channel.id, label: channel.label })),
             required: true,


### PR DESCRIPTION
Instead of loading channels or users by default, allow the user to manually set the user or channel id. This will allow large orgs the ability to manually set schedules without dealing with rate limiting issues with hitting the conversations.list() api