### PR TITLE
Update CloudBuild run and deploy for GCP

### DIFF
--- a/cloudbuild_container.yaml
+++ b/cloudbuild_container.yaml
@@ -1,6 +1,14 @@
 steps:
+  # Build the Action Hub container
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/actionhub', '.']
+  # Push the container to the container registry
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'push', 'gcr.io/$PROJECT_ID/actionhub' ]
+- name: 'gcr.io/cloud-builders/gcloud'
+  # Deploy the container to CloudRun
+  # Existing parameters in CloudRun will not be overriden with a deploy unless specified here
+  args: [ 'run', 'deploy', 'actionhub', '--image', 'gcr.io/$PROJECT_ID/actionhub', '--region', '${_REGION}', '--platform', 'managed' ]
 options:
   logging: CLOUD_LOGGING_ONLY
 images: ['gcr.io/$PROJECT_ID/actionhub']


### PR DESCRIPTION
Using `gcloud builds submit --config="cloudbuild-container.yaml"` - build and deploy an action hub to a GCP project. Env vars still need to be set however