### PR TITLE
Airtable OAuth2

### DIFF
--- a/lib/actions/airtable/airtable.d.ts
+++ b/lib/actions/airtable/airtable.d.ts
@@ -1,21 +1,24 @@
 import * as Hub from "../../hub";
-export declare class AirtableAction extends Hub.Action {
+import * as gaxios from "gaxios";
+export declare class AirtableAction extends Hub.OAuthAction {
     name: string;
     label: string;
     iconName: string;
     description: string;
-    params: {
-        description: string;
-        label: string;
-        name: string;
-        required: boolean;
-        sensitive: boolean;
-    }[];
+    params: never[];
     supportedActionTypes: Hub.ActionType[];
     supportedFormats: Hub.ActionFormat[];
     supportedFormattings: Hub.ActionFormatting[];
     supportedVisualizationFormattings: Hub.ActionVisualizationFormatting[];
+    SCOPE: string;
     execute(request: Hub.ActionRequest): Promise<Hub.ActionResponse>;
-    form(): Promise<Hub.ActionForm>;
+    checkBaseList(request: Hub.ActionRequest): Promise<gaxios.GaxiosResponse<unknown> | null>;
+    form(request: Hub.ActionRequest): Promise<Hub.ActionForm>;
+    oauthCheck(_request: Hub.ActionRequest): Promise<boolean>;
+    oauthFetchInfo(urlParams: {
+        [p: string]: string;
+    }, redirectUri: string): Promise<void>;
+    oauthUrl(redirectUri: string, encryptedState: string): Promise<string>;
     private airtableClientFromRequest;
+    private refreshTokens;
 }

--- a/lib/actions/airtable/airtable.js
+++ b/lib/actions/airtable/airtable.js
@@ -11,27 +11,24 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.AirtableAction = void 0;
 const Hub = require("../../hub");
+const crypto = require("crypto");
+const gaxios = require("gaxios");
+const qs = require("qs");
+const winston = require("winston");
 const airtable = require("airtable");
-class AirtableAction extends Hub.Action {
+class AirtableAction extends Hub.OAuthAction {
     constructor() {
         super(...arguments);
         this.name = "airtable";
         this.label = "Airtable";
         this.iconName = "airtable/airtable.png";
         this.description = "Add records to an Airtable table.";
-        this.params = [
-            {
-                description: "API key for Airtable from https://airtable.com/account.",
-                label: "Airtable API Key",
-                name: "airtable_api_key",
-                required: true,
-                sensitive: true,
-            },
-        ];
+        this.params = [];
         this.supportedActionTypes = [Hub.ActionType.Query];
         this.supportedFormats = [Hub.ActionFormat.JsonDetail];
         this.supportedFormattings = [Hub.ActionFormatting.Unformatted];
         this.supportedVisualizationFormattings = [Hub.ActionVisualizationFormatting.Noapply];
+        this.SCOPE = "data.records:write schema.bases:read schema.bases:write";
     }
     execute(request) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -59,7 +56,7 @@ class AirtableAction extends Hub.Action {
             });
             let response;
             try {
-                const airtableClient = this.airtableClientFromRequest(request);
+                const airtableClient = yield this.airtableClientFromRequest(request);
                 const base = airtableClient.base(request.formParams.base);
                 const table = base(request.formParams.table);
                 yield Promise.all(records.map((record) => __awaiter(this, void 0, void 0, function* () {
@@ -81,26 +78,190 @@ class AirtableAction extends Hub.Action {
             return new Hub.ActionResponse(response);
         });
     }
-    form() {
+    checkBaseList(request) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (request.params.state_json) {
+                const stateJson = JSON.parse(request.params.state_json);
+                const response = yield this.refreshTokens(stateJson.tokens.refresh_token);
+                return gaxios.request({
+                    method: "GET",
+                    url: "https://api.airtable.com/v0/meta/bases",
+                    headers: {
+                        Authorization: `Bearer ${response.data.access_token}`,
+                    },
+                }).catch((err) => {
+                    winston.error(JSON.stringify(err));
+                    throw "Error listing bases, oauth probably bad.";
+                });
+            }
+            else {
+                return null;
+            }
+        });
+    }
+    form(request) {
         return __awaiter(this, void 0, void 0, function* () {
             const form = new Hub.ActionForm();
-            form.fields = [{
-                    label: "Airtable Base",
-                    name: "base",
-                    required: true,
-                    type: "string",
-                }, {
-                    label: "Airtable Table",
-                    name: "table",
-                    required: true,
-                    type: "string",
-                }];
+            try {
+                const response = yield this.checkBaseList(request);
+                if (response === null) {
+                    // @ts-ignore
+                    throw "Error with checking baselist";
+                }
+                winston.info(JSON.stringify(response));
+                form.fields = [{
+                        label: "Airtable Base",
+                        name: "base",
+                        required: true,
+                        type: "string",
+                    }, {
+                        label: "Airtable Table",
+                        name: "table",
+                        required: true,
+                        type: "string",
+                    }];
+            }
+            catch (e) {
+                // prevents others from impersonating you
+                const codeVerifier = crypto.randomBytes(96).toString("base64url"); // 128 characters
+                const actionCrypto = new Hub.ActionCrypto();
+                const jsonString = JSON.stringify({ stateurl: request.params.state_url, verifier: codeVerifier });
+                const ciphertextBlob = yield actionCrypto.encrypt(jsonString).catch((err) => {
+                    winston.error("Encryption not correctly configured");
+                    throw err;
+                });
+                form.fields = [{
+                        label: "Login",
+                        name: "oauth",
+                        type: "oauth_link",
+                        oauth_url: `${process.env.ACTION_HUB_BASE_URL}/actions/${this.name}/oauth?state=${ciphertextBlob}`,
+                    }];
+            }
             return form;
         });
     }
+    oauthCheck(_request) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return false;
+        });
+    }
+    oauthFetchInfo(urlParams, redirectUri) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const actionCrypto = new Hub.ActionCrypto();
+            const plaintext = yield actionCrypto.decrypt(urlParams.state).catch((err) => {
+                winston.error("Encryption not correctly configured" + err);
+                throw err;
+            });
+            const payload = JSON.parse(plaintext);
+            const dataString = qs.stringify({
+                clientId: process.env.AIRTABLE_CLIENT_ID,
+                grant_type: "authorization_code",
+                code_verifier: payload.verifier,
+                redirect_uri: redirectUri,
+                code: urlParams.code,
+            });
+            const encodedCreds = Buffer.from(`${process.env.AIRTABLE_CLIENT_ID}:${process.env.AIRTABLE_CLIENT_SECRET}`)
+                .toString("base64");
+            const response = yield gaxios.request({
+                method: "POST",
+                url: "https://www.airtable.com/oauth2/v1/token",
+                headers: {
+                    "Authorization": `Basic ${encodedCreds}`,
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                data: dataString,
+            });
+            JSON.stringify(response.data);
+            // Pass back context to Looker
+            if (response.status === 200) {
+                const data = response.data;
+                yield gaxios.request({
+                    url: payload.stateurl,
+                    method: "POST",
+                    body: JSON.stringify({ tokens: {
+                            refresh_token: data.refresh_token,
+                            access_token: data.access_token,
+                        }, redirect: redirectUri }),
+                }).catch((_err) => { winston.error(_err.toString()); });
+            }
+            else {
+                winston.warn("Oauth for Airtable unsuccessful");
+                throw "OAuth did not work";
+            }
+        });
+    }
+    oauthUrl(redirectUri, encryptedState) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const clientId = process.env.AIRTABLE_CLIENT_ID ? process.env.AIRTABLE_CLIENT_ID : "must exist";
+            const actionCrypto = new Hub.ActionCrypto();
+            const plaintext = yield actionCrypto.decrypt(encryptedState).catch((err) => {
+                winston.error("Encryption not correctly configured" + err);
+                throw err;
+            });
+            const payload = JSON.parse(plaintext);
+            // prevents others from impersonating you
+            const codeVerifier = payload.verifier; // 128 characters
+            const codeChallengeMethod = "S256";
+            const codeChallenge = crypto
+                .createHash("sha256")
+                .update(codeVerifier) // hash the code verifier with the sha256 algorithm
+                .digest("base64") // base64 encode, needs to be transformed to base64url
+                .replace(/=/g, "") // remove =
+                .replace(/\+/g, "-") // replace + with -
+                .replace(/\//g, "_"); // replace / with _ now base64url encoded
+            // build the authorization URL
+            const authorizationUrl = new URL(`https://www.airtable.com/oauth2/v1/authorize`);
+            authorizationUrl.searchParams.set("code_challenge", codeChallenge);
+            authorizationUrl.searchParams.set("code_challenge_method", codeChallengeMethod);
+            authorizationUrl.searchParams.set("state", encryptedState);
+            authorizationUrl.searchParams.set("client_id", clientId);
+            authorizationUrl.searchParams.set("redirect_uri", redirectUri);
+            authorizationUrl.searchParams.set("response_type", "code");
+            // your OAuth integration register with these scopes in the management page
+            authorizationUrl.searchParams.set("scope", this.SCOPE);
+            return authorizationUrl.toString();
+        });
+    }
     airtableClientFromRequest(request) {
-        return new airtable({ apiKey: request.params.airtable_api_key });
+        return __awaiter(this, void 0, void 0, function* () {
+            if (request.params.state_json) {
+                const stateJson = JSON.parse(request.params.state_json);
+                const response = yield this.refreshTokens(stateJson.tokens.refresh_token);
+                return new airtable({ apiKey: response.data.access_token });
+            }
+            else {
+                return null;
+            }
+        });
+    }
+    refreshTokens(refreshToken) {
+        return __awaiter(this, void 0, void 0, function* () {
+            try {
+                const dataString = qs.stringify({
+                    client_id: process.env.AIRTABLE_CLIENT_ID,
+                    grant_type: "refresh_token",
+                    refresh_token: refreshToken,
+                });
+                const encodedCreds = Buffer.from(`${process.env.AIRTABLE_CLIENT_ID}:${process.env.AIRTABLE_CLIENT_SECRET}`)
+                    .toString("base64");
+                return yield gaxios.request({
+                    method: "POST",
+                    url: "https://www.airtable.com/oauth2/v1/token",
+                    headers: {
+                        "Authorization": `Basic ${encodedCreds}`,
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                    data: dataString,
+                });
+            }
+            catch (e) {
+                winston.warn("Error with Airtable Access Token Refresh");
+                return { data: {} };
+            }
+        });
     }
 }
 exports.AirtableAction = AirtableAction;
-Hub.addAction(new AirtableAction());
+if (process.env.AIRTABLE_CLIENT_ID && process.env.AIRTABLE_CLIENT_SECRET) {
+    Hub.addAction(new AirtableAction());
+}

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/twilio": "^2.11.0",
     "@types/uuid": "^3.4.9",
     "@types/winston": "^2.4.4",
-    "airtable": "^0.11.4",
+    "airtable": "^0.12.2",
     "analytics-node": "^3.3.0",
     "async-mutex": "^0.1.4",
     "aws-sdk": "^2.732.0",

--- a/src/actions/airtable/airtable.ts
+++ b/src/actions/airtable/airtable.ts
@@ -81,9 +81,8 @@ export class AirtableAction extends Hub.OAuthAction {
         headers: {
           Authorization: `Bearer ${(response.data as any).access_token}`,
         },
-      }).catch((err) => {
-        winston.error(JSON.stringify(err))
-        throw "Error listing bases, oauth probably bad."
+      }).catch((_err) => {
+        throw "Error listing bases, oauth credentials most likely expired."
       })
     } else {
       return null
@@ -98,7 +97,6 @@ export class AirtableAction extends Hub.OAuthAction {
         // @ts-ignore
         throw "Error with checking baselist"
       }
-      winston.info(JSON.stringify(response))
       form.fields = [{
         label: "Airtable Base",
         name: "base",
@@ -161,7 +159,6 @@ export class AirtableAction extends Hub.OAuthAction {
       },
       data: dataString,
     })
-    JSON.stringify(response.data)
     // Pass back context to Looker
     if (response.status === 200) {
       const data: any = response.data

--- a/src/actions/airtable/airtable.ts
+++ b/src/actions/airtable/airtable.ts
@@ -1,26 +1,25 @@
 import * as Hub from "../../hub"
 
+import * as crypto from "crypto"
+import * as gaxios from "gaxios"
+import * as qs from "qs"
+import * as winston from "winston"
+
 const airtable: any = require("airtable")
 
-export class AirtableAction extends Hub.Action {
+export class AirtableAction extends Hub.OAuthAction {
 
   name = "airtable"
   label = "Airtable"
   iconName = "airtable/airtable.png"
   description = "Add records to an Airtable table."
-  params = [
-    {
-      description: "API key for Airtable from https://airtable.com/account.",
-      label: "Airtable API Key",
-      name: "airtable_api_key",
-      required: true,
-      sensitive: true,
-    },
-  ]
+  params = []
   supportedActionTypes = [Hub.ActionType.Query]
   supportedFormats = [Hub.ActionFormat.JsonDetail]
   supportedFormattings = [Hub.ActionFormatting.Unformatted]
   supportedVisualizationFormattings = [Hub.ActionVisualizationFormatting.Noapply]
+
+  const SCOPE = "data.records:read data.records:write"
 
   async execute(request: Hub.ActionRequest) {
     if (!(request.attachment && request.attachment.dataJSON)) {
@@ -72,8 +71,29 @@ export class AirtableAction extends Hub.Action {
     return new Hub.ActionResponse(response)
   }
 
-  async form() {
+  async form(request: Hub.ActionRequest) {
     const form = new Hub.ActionForm()
+    try {
+      const airtableClient = this.airtableClientFromRequest(request)
+      airtableClient.list()
+    } catch (e) {
+      // prevents others from impersonating you
+      const codeVerifier = crypto.randomBytes(96).toString("base64url") // 128 characters
+
+      const actionCrypto = new Hub.ActionCrypto()
+      const jsonString = JSON.stringify({stateurl: request.params.state_url, verifier: codeVerifier})
+      const ciphertextBlob = await actionCrypto.encrypt(jsonString).catch((err: string) => {
+        winston.error("Encryption not correctly configured")
+        throw err
+      })
+
+      form.fields = [{
+        label: "Login",
+        name: "oauth",
+        type: "oauth_link",
+        oauth_url: `${process.env.ACTION_HUB_BASE_URL}/actions/${this.name}/oauth?state=${ciphertextBlob}`,
+      }]
+    }
     form.fields = [{
       label: "Airtable Base",
       name: "base",
@@ -88,10 +108,94 @@ export class AirtableAction extends Hub.Action {
     return form
   }
 
+  async oauthCheck(request: Hub.ActionRequest) {
+    return false
+  }
+
+  async oauthFetchInfo(urlParams: { [p: string]: string }, redirectUri: string) {
+    const actionCrypto = new Hub.ActionCrypto()
+    const plaintext = await actionCrypto.decrypt(urlParams.state).catch((err: string) => {
+      winston.error("Encryption not correctly configured" + err)
+      throw err
+    })
+    const payload = JSON.parse(plaintext)
+
+    // const tokens = await this.getAccessTokenCredentialsFromCode(redirectUri, urlParams.code)
+    const dataString = qs.stringify({
+      clientId: process.env.AIRTABLE_CLIENT_ID,
+      grant_type: "authorization_code",
+      code_verifier: payload.verifier,
+      redirect_uri: redirectUri,
+      code: urlParams.code,
+    })
+    // @ts-ignore
+    const encodedCreds = Buffer.from(`${process.env.AIRTABLE_CLIENT_ID}:${process.env.AIRTABLE_CLIENT_SECRET}`)
+        .toString("base64")
+    const response = await gaxios.request({
+      method: "POST",
+      url: "https://www.airtable.com/oauth2/v1/token",
+      headers: {
+        // "Authorization": `Basic ${encodedCreds}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      data: dataString,
+    })
+    JSON.stringify(response.data)
+    // Pass back context to Looker
+    await gaxios.request({
+      url: payload.stateurl,
+      method: "POST",
+      body: JSON.stringify({tokens, redirect: redirectUri}),
+    }).catch((_err) => { winston.error(_err.toString()) })
+  }
+
+  async oauthUrl(redirectUri: string, encryptedState: string) {
+
+    const clientId = process.env.AIRTABLE_CLIENT_ID || "nope"
+
+    const actionCrypto = new Hub.ActionCrypto()
+    const plaintext = await actionCrypto.decrypt(encryptedState).catch((err: string) => {
+      winston.error("Encryption not correctly configured" + err)
+      throw err
+    })
+    const payload = JSON.parse(plaintext)
+
+    // prevents others from impersonating you
+    const codeVerifier = payload.verifier// 128 characters
+    const codeChallengeMethod = "S256"
+    const codeChallenge = crypto
+        .createHash("sha256")
+        .update(codeVerifier) // hash the code verifier with the sha256 algorithm
+        .digest("base64") // base64 encode, needs to be transformed to base64url
+        .replace(/=/g, "") // remove =
+        .replace(/\+/g, "-") // replace + with -
+        .replace(/\//g, "_") // replace / with _ now base64url encoded
+    // build the authorization URL
+    const authorizationUrl = new URL(`https://www.airtable.com/oauth2/v1/authorize`)
+    authorizationUrl.searchParams.set("code_challenge", codeChallenge)
+    authorizationUrl.searchParams.set("code_challenge_method", codeChallengeMethod)
+    authorizationUrl.searchParams.set("state", encryptedState)
+    authorizationUrl.searchParams.set("client_id", clientId)
+    authorizationUrl.searchParams.set("redirect_uri", redirectUri)
+    authorizationUrl.searchParams.set("response_type", "code")
+    // your OAuth integration register with these scopes in the management page
+    authorizationUrl.searchParams.set("scope", this.SCOPE)
+
+    return authorizationUrl.toString()
+  }
+
   private airtableClientFromRequest(request: Hub.ActionRequest) {
-    return new airtable({apiKey: request.params.airtable_api_key})
+    // todo: extract tokens and handle non-infinite refresh
+    if (request.params.state_json) {
+      const stateJson = JSON.parse(request.params.state_json)
+      return new airtable({customHeaders: stateJson})
+    } else {
+      return null
+    }
   }
 
 }
 
-Hub.addAction(new AirtableAction())
+if (process.env.AIRTABLE_CLIENT_ID && process.env.AIRTABLE_CLIENT_SECRET) {
+  Hub.addAction(new AirtableAction())
+}

--- a/src/actions/airtable/airtable.ts
+++ b/src/actions/airtable/airtable.ts
@@ -217,6 +217,7 @@ export class AirtableAction extends Hub.OAuthAction {
       const response = await this.refreshTokens(stateJson.tokens.refresh_token)
       return new airtable({apiKey: (response.data as any).access_token})
     } else {
+      winston.info("No state json", {webhookId: request.webhookId})
       return null
     }
   }

--- a/src/actions/airtable/airtable.ts
+++ b/src/actions/airtable/airtable.ts
@@ -94,7 +94,7 @@ export class AirtableAction extends Hub.OAuthAction {
     const form = new Hub.ActionForm()
     try {
       const response = await this.checkBaseList(request)
-      if (response === undefined) {
+      if (response === null) {
         // @ts-ignore
         throw "Error with checking baselist"
       }
@@ -169,7 +169,7 @@ export class AirtableAction extends Hub.OAuthAction {
         url: payload.stateurl,
         method: "POST",
         body: JSON.stringify({tokens: {
-            refresh_token: data.refresh_token || "chuckle",
+            refresh_token: data.refresh_token,
             access_token: data.access_token,
           }, redirect: redirectUri}),
       }).catch((_err) => { winston.error(_err.toString()) })
@@ -181,7 +181,7 @@ export class AirtableAction extends Hub.OAuthAction {
 
   async oauthUrl(redirectUri: string, encryptedState: string) {
 
-    const clientId = process.env.AIRTABLE_CLIENT_ID || "must exist"
+    const clientId = process.env.AIRTABLE_CLIENT_ID ?  process.env.AIRTABLE_CLIENT_ID : "must exist"
 
     const actionCrypto = new Hub.ActionCrypto()
     const plaintext = await actionCrypto.decrypt(encryptedState).catch((err: string) => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -10,7 +10,7 @@ import * as ExtendedProcessQueue from "../xpc/extended_process_queue"
 import * as apiKey from "./api_key"
 const expressWinston = require("express-winston")
 const uparse = require("url")
-const blocked = require("blocked-at")
+//const blocked = require("blocked-at")
 
 const TOKEN_REGEX = new RegExp(/[T|t]oken token="(.*)"/)
 const statusJsonPath = path.resolve(`${__dirname}/../../status.json`)
@@ -38,9 +38,9 @@ export default class Server implements Hub.RouteBuilder {
       }).install()
     }
 
-    blocked((time: number, stack: string[]) => {
-      winston.warn(`Event loop blocked for ${time}ms, operation started here:\n${stack.join("\n")}`)
-    }, {threshold: 100})
+    // blocked((time: number, stack: string[]) => {
+    //   winston.warn(`Event loop blocked for ${time}ms, operation started here:\n${stack.join("\n")}`)
+    // }, {threshold: 100})
 
     if (!process.env.ACTION_HUB_BASE_URL) {
       throw new Error("No ACTION_HUB_BASE_URL environment variable set.")

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -10,7 +10,7 @@ import * as ExtendedProcessQueue from "../xpc/extended_process_queue"
 import * as apiKey from "./api_key"
 const expressWinston = require("express-winston")
 const uparse = require("url")
-//const blocked = require("blocked-at")
+const blocked = require("blocked-at")
 
 const TOKEN_REGEX = new RegExp(/[T|t]oken token="(.*)"/)
 const statusJsonPath = path.resolve(`${__dirname}/../../status.json`)
@@ -38,9 +38,9 @@ export default class Server implements Hub.RouteBuilder {
       }).install()
     }
 
-    // blocked((time: number, stack: string[]) => {
-    //   winston.warn(`Event loop blocked for ${time}ms, operation started here:\n${stack.join("\n")}`)
-    // }, {threshold: 100})
+    blocked((time: number, stack: string[]) => {
+      winston.warn(`Event loop blocked for ${time}ms, operation started here:\n${stack.join("\n")}`)
+    }, {threshold: 100})
 
     if (!process.env.ACTION_HUB_BASE_URL) {
       throw new Error("No ACTION_HUB_BASE_URL environment variable set.")

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,10 +897,10 @@ agent-base@6:
   dependencies:
     debug "4"
 
-airtable@^0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/airtable/-/airtable-0.11.4.tgz#1f8bef44c82a185f05655fc5e9c9563b1ee775ec"
-  integrity sha512-y8sEi/sMEdgtgvv0V8AhJyFQB9za+6qGIxllt60Ey5ELBgu+bNEc1hjY2aqzp9C38p0ORfaeRS5RSFWlcq11Aw==
+airtable@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/airtable/-/airtable-0.12.2.tgz#e53e66db86744f9bc684faa58881d6c9c12f0e6f"
+  integrity sha512-HS3VytUBTKj8A0vPl7DDr5p/w3IOGv6RXL0fv7eczOWAtj9Xe8ri4TAiZRXoOyo+Z/COADCj+oARFenbxhmkIg==
   dependencies:
     "@types/node" ">=8.0.0 <15"
     abort-controller "^3.0.0"


### PR DESCRIPTION
Adds Airatable OAuth. Since the library provided by Airtable does not provide any wrappers around OAuth, we have opted to implement it on its own. Breaking with original API_KEYS sunset on Jan 31 2024