### PR TITLE
Bump actions version to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "looker-action-hub",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "",
   "main": "lib/index",
   "scripts": {


### PR DESCRIPTION
This version bump includes the change from Airtable API Key to Airtable OAuth flow.