### PR TITLE
Upgrade Facebook Marketing API to v19.0

### DIFF
--- a/src/actions/facebook/lib/api.ts
+++ b/src/actions/facebook/lib/api.ts
@@ -2,7 +2,7 @@ import * as gaxios from "gaxios"
 import * as winston from "winston"
 import {formatFullDate, isNullOrUndefined, sanitizeError, sortCompare} from "./util"
 
-export const API_VERSION = "v16.0"
+export const API_VERSION = "v19.0"
 export const API_BASE_URL = `https://graph.facebook.com/${API_VERSION}/`
 export const CUSTOMER_LIST_SOURCE_TYPES = {
     // Used by Facebook for unknown purposes.


### PR DESCRIPTION
Upgrade Facebook Marketing API to v19.0 because v16.0 is deprecated and not allowed to use since 2023-02-06.