### PR TITLE
Update Airtable Flow to reset state on every request

### DIFF
--- a/lib/actions/airtable/airtable.d.ts
+++ b/lib/actions/airtable/airtable.d.ts
@@ -12,7 +12,7 @@ export declare class AirtableAction extends Hub.OAuthAction {
     supportedVisualizationFormattings: Hub.ActionVisualizationFormatting[];
     SCOPE: string;
     execute(request: Hub.ActionRequest): Promise<Hub.ActionResponse>;
-    checkBaseList(request: Hub.ActionRequest): Promise<gaxios.GaxiosResponse<unknown> | null>;
+    checkBaseList(token: string): Promise<gaxios.GaxiosResponse<unknown>>;
     form(request: Hub.ActionRequest): Promise<Hub.ActionForm>;
     oauthCheck(_request: Hub.ActionRequest): Promise<boolean>;
     oauthFetchInfo(urlParams: {

--- a/lib/actions/airtable/airtable.js
+++ b/lib/actions/airtable/airtable.js
@@ -15,6 +15,7 @@ const crypto = require("crypto");
 const gaxios = require("gaxios");
 const qs = require("qs");
 const winston = require("winston");
+const hub_1 = require("../../hub");
 const airtable = require("airtable");
 class AirtableAction extends Hub.OAuthAction {
     constructor() {
@@ -54,9 +55,24 @@ class AirtableAction extends Hub.OAuthAction {
                 }
                 return record;
             });
-            let response;
+            const response = new hub_1.ActionResponse({ success: true });
+            const state = new hub_1.ActionState();
             try {
-                const airtableClient = yield this.airtableClientFromRequest(request);
+                let accessToken;
+                if (request.params.state_json) {
+                    const stateJson = JSON.parse(request.params.state_json);
+                    const refreshResponse = yield this.refreshTokens(stateJson.params.state_json);
+                    accessToken = refreshResponse.data.access_token;
+                    // Every single access_token invalidates previous refresh_token. Need to
+                    // update state on EVERY request
+                    state.data = JSON.stringify({
+                        tokens: {
+                            refresh_token: refreshResponse.data.refresh_token,
+                            access_token: accessToken,
+                        },
+                    });
+                }
+                const airtableClient = yield this.airtableClientFromRequest(accessToken);
                 const base = airtableClient.base(request.formParams.base);
                 const table = base(request.formParams.table);
                 yield Promise.all(records.map((record) => __awaiter(this, void 0, void 0, function* () {
@@ -73,42 +89,44 @@ class AirtableAction extends Hub.OAuthAction {
                 })));
             }
             catch (e) {
-                response = { success: false, message: e.message };
+                response.success = false;
+                response.message = e.message;
             }
+            response.state = state;
             return new Hub.ActionResponse(response);
         });
     }
-    checkBaseList(request) {
+    checkBaseList(token) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (request.params.state_json) {
-                const stateJson = JSON.parse(request.params.state_json);
-                const response = yield this.refreshTokens(stateJson.tokens.refresh_token);
-                return gaxios.request({
-                    method: "GET",
-                    url: "https://api.airtable.com/v0/meta/bases",
-                    headers: {
-                        Authorization: `Bearer ${response.data.access_token}`,
-                    },
-                }).catch((err) => {
-                    winston.error(JSON.stringify(err));
-                    throw "Error listing bases, oauth probably bad.";
-                });
-            }
-            else {
-                return null;
-            }
+            return gaxios.request({
+                method: "GET",
+                url: "https://api.airtable.com/v0/meta/bases",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            }).catch((_err) => {
+                throw "Error listing bases, oauth credentials most likely expired.";
+            });
         });
     }
     form(request) {
         return __awaiter(this, void 0, void 0, function* () {
             const form = new Hub.ActionForm();
             try {
-                const response = yield this.checkBaseList(request);
-                if (response === null) {
-                    // @ts-ignore
-                    throw "Error with checking baselist";
+                let accessToken;
+                if (request.params.state_json) {
+                    const stateJson = JSON.parse(request.params.state_json);
+                    const refreshResponse = yield this.refreshTokens(stateJson.tokens.refresh_token);
+                    accessToken = refreshResponse.data.access_token;
+                    // Every single access_token invalidates previous refresh_token. Need to
+                    // update state on EVERY request
+                    form.state = new hub_1.ActionState();
+                    form.state.data = JSON.stringify({ tokens: {
+                            refresh_token: refreshResponse.data.refresh_token,
+                            access_token: accessToken,
+                        } });
                 }
-                winston.info(JSON.stringify(response));
+                yield this.checkBaseList(accessToken);
                 form.fields = [{
                         label: "Airtable Base",
                         name: "base",
@@ -171,7 +189,6 @@ class AirtableAction extends Hub.OAuthAction {
                 },
                 data: dataString,
             });
-            JSON.stringify(response.data);
             // Pass back context to Looker
             if (response.status === 200) {
                 const data = response.data;
@@ -222,16 +239,9 @@ class AirtableAction extends Hub.OAuthAction {
             return authorizationUrl.toString();
         });
     }
-    airtableClientFromRequest(request) {
+    airtableClientFromRequest(token) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (request.params.state_json) {
-                const stateJson = JSON.parse(request.params.state_json);
-                const response = yield this.refreshTokens(stateJson.tokens.refresh_token);
-                return new airtable({ apiKey: response.data.access_token });
-            }
-            else {
-                return null;
-            }
+            return new airtable({ apiKey: token });
         });
     }
     refreshTokens(refreshToken) {

--- a/lib/actions/airtable/airtable.js
+++ b/lib/actions/airtable/airtable.js
@@ -61,7 +61,7 @@ class AirtableAction extends Hub.OAuthAction {
                 let accessToken;
                 if (request.params.state_json) {
                     const stateJson = JSON.parse(request.params.state_json);
-                    const refreshResponse = yield this.refreshTokens(stateJson.params.state_json);
+                    const refreshResponse = yield this.refreshTokens(stateJson.tokens.refresh_token);
                     accessToken = refreshResponse.data.access_token;
                     // Every single access_token invalidates previous refresh_token. Need to
                     // update state on EVERY request

--- a/lib/actions/google/drive/google_drive.js
+++ b/lib/actions/google/drive/google_drive.js
@@ -44,6 +44,7 @@ class GoogleDriveAction extends Hub.OAuthAction {
                 if (!filename) {
                     resp.success = false;
                     resp.message = "Error creating filename";
+                    winston.error("Error creating filename");
                     return resp;
                 }
                 try {
@@ -53,6 +54,7 @@ class GoogleDriveAction extends Hub.OAuthAction {
                 catch (e) {
                     resp.success = false;
                     resp.message = e.message;
+                    winston.error("Error while sending data " + e.message);
                 }
             }
             else {
@@ -136,7 +138,7 @@ class GoogleDriveAction extends Hub.OAuthAction {
                     }
                 }
                 catch (e) {
-                    winston.warn("Log in fail");
+                    winston.error("Can not sign in to Google", { webhookId: request.webhookId });
                 }
             }
             return this.loginForm(request);
@@ -311,6 +313,7 @@ class GoogleDriveAction extends Hub.OAuthAction {
                     " once to your Google account.",
                 oauth_url: `${process.env.ACTION_HUB_BASE_URL}/actions/${this.name}/oauth?state=${ciphertextBlob}`,
             });
+            winston.debug(`Login form, OAuthURL${process.env.ACTION_HUB_BASE_URL}/actions/${this.name}/oauth?state=${ciphertextBlob}`);
             return form;
         });
     }

--- a/lib/actions/google/drive/sheets/google_sheets.js
+++ b/lib/actions/google/drive/sheets/google_sheets.js
@@ -47,6 +47,7 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                 if (!filename) {
                     resp.success = false;
                     resp.message = "Error creating filename";
+                    winston.error("Error creating file name");
                     return resp;
                 }
                 else if (!filename.match(/\.csv$/)) {

--- a/src/actions/airtable/airtable.ts
+++ b/src/actions/airtable/airtable.ts
@@ -55,7 +55,7 @@ export class AirtableAction extends Hub.OAuthAction {
       let accessToken
       if (request.params.state_json) {
         const stateJson = JSON.parse(request.params.state_json)
-        const refreshResponse = await this.refreshTokens(stateJson.params.state_json)
+        const refreshResponse = await this.refreshTokens(stateJson.tokens.refresh_token)
         accessToken = (refreshResponse as any).data.access_token
         // Every single access_token invalidates previous refresh_token. Need to
         // update state on EVERY request

--- a/src/actions/airtable/airtable.ts
+++ b/src/actions/airtable/airtable.ts
@@ -4,6 +4,7 @@ import * as crypto from "crypto"
 import * as gaxios from "gaxios"
 import * as qs from "qs"
 import * as winston from "winston"
+import {ActionResponse, ActionState} from "../../hub"
 
 const airtable: any = require("airtable")
 
@@ -48,9 +49,24 @@ export class AirtableAction extends Hub.OAuthAction {
       return record
     })
 
-    let response
+    const response = new ActionResponse({success: true})
+    const state = new ActionState()
     try {
-      const airtableClient = await this.airtableClientFromRequest(request)
+      let accessToken
+      if (request.params.state_json) {
+        const stateJson = JSON.parse(request.params.state_json)
+        const refreshResponse = await this.refreshTokens(stateJson.params.state_json)
+        accessToken = (refreshResponse as any).data.access_token
+        // Every single access_token invalidates previous refresh_token. Need to
+        // update state on EVERY request
+        state.data = JSON.stringify({
+          tokens: {
+            refresh_token: (refreshResponse as any).data.refresh_token,
+            access_token: accessToken,
+          },
+        })
+      }
+      const airtableClient = await this.airtableClientFromRequest(accessToken)
       const base = airtableClient.base(request.formParams.base)
       const table = base(request.formParams.table)
 
@@ -66,37 +82,42 @@ export class AirtableAction extends Hub.OAuthAction {
         })
       }))
     } catch (e: any) {
-      response = { success: false, message: e.message }
+      response.success = false
+      response.message = e.message
     }
+    response.state = state
     return new Hub.ActionResponse(response)
   }
 
-  async checkBaseList(request: Hub.ActionRequest) {
-    if (request.params.state_json) {
-      const stateJson = JSON.parse(request.params.state_json)
-      const response = await this.refreshTokens(stateJson.tokens.refresh_token)
-      return gaxios.request({
-        method: "GET",
-        url: "https://api.airtable.com/v0/meta/bases",
-        headers: {
-          Authorization: `Bearer ${(response.data as any).access_token}`,
-        },
-      }).catch((_err) => {
-        throw "Error listing bases, oauth credentials most likely expired."
-      })
-    } else {
-      return null
-    }
+  async checkBaseList(token: String) {
+    return gaxios.request({
+      method: "GET",
+      url: "https://api.airtable.com/v0/meta/bases",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }).catch((_err) => {
+      throw "Error listing bases, oauth credentials most likely expired."
+    })
   }
 
   async form(request: Hub.ActionRequest) {
     const form = new Hub.ActionForm()
     try {
-      const response = await this.checkBaseList(request)
-      if (response === null) {
-        // @ts-ignore
-        throw "Error with checking baselist"
+      let accessToken
+      if (request.params.state_json) {
+        const stateJson = JSON.parse(request.params.state_json)
+        const refreshResponse = await this.refreshTokens(stateJson.params.state_json)
+        accessToken = (refreshResponse as any).data.access_token
+        // Every single access_token invalidates previous refresh_token. Need to
+        // update state on EVERY request
+        form.state = new ActionState()
+        form.state.data = JSON.stringify({tokens: {
+            refresh_token: (refreshResponse as any).data.refresh_token,
+            access_token: accessToken,
+          }})
       }
+      await this.checkBaseList(accessToken)
       form.fields = [{
         label: "Airtable Base",
         name: "base",
@@ -211,15 +232,8 @@ export class AirtableAction extends Hub.OAuthAction {
     return authorizationUrl.toString()
   }
 
-  private async airtableClientFromRequest(request: Hub.ActionRequest) {
-    if (request.params.state_json) {
-      const stateJson = JSON.parse(request.params.state_json)
-      const response = await this.refreshTokens(stateJson.tokens.refresh_token)
-      return new airtable({apiKey: (response.data as any).access_token})
-    } else {
-      winston.info("No state json", {webhookId: request.webhookId})
-      return null
-    }
+  private async airtableClientFromRequest(token: String) {
+    return new airtable({apiKey: token})
   }
 
   private async refreshTokens(refreshToken: string) {

--- a/src/actions/airtable/airtable.ts
+++ b/src/actions/airtable/airtable.ts
@@ -89,7 +89,7 @@ export class AirtableAction extends Hub.OAuthAction {
     return new Hub.ActionResponse(response)
   }
 
-  async checkBaseList(token: String) {
+  async checkBaseList(token: string) {
     return gaxios.request({
       method: "GET",
       url: "https://api.airtable.com/v0/meta/bases",
@@ -107,7 +107,7 @@ export class AirtableAction extends Hub.OAuthAction {
       let accessToken
       if (request.params.state_json) {
         const stateJson = JSON.parse(request.params.state_json)
-        const refreshResponse = await this.refreshTokens(stateJson.params.state_json)
+        const refreshResponse = await this.refreshTokens(stateJson.tokens.refresh_token)
         accessToken = (refreshResponse as any).data.access_token
         // Every single access_token invalidates previous refresh_token. Need to
         // update state on EVERY request
@@ -232,7 +232,7 @@ export class AirtableAction extends Hub.OAuthAction {
     return authorizationUrl.toString()
   }
 
-  private async airtableClientFromRequest(token: String) {
+  private async airtableClientFromRequest(token: string) {
     return new airtable({apiKey: token})
   }
 

--- a/src/actions/airtable/test_airtable.ts
+++ b/src/actions/airtable/test_airtable.ts
@@ -153,6 +153,7 @@ describe(`${action.constructor.name} unit tests`, () => {
         success: false,
         message: "Could not find table Contacts123 in application app",
         refreshQuery: false,
+        state: {},
         validationErrors: [],
       }).then(() => {
         stubPost.restore()
@@ -170,7 +171,7 @@ describe(`${action.constructor.name} unit tests`, () => {
     it("has form with base and table param", (done) => {
       const request = new Hub.ActionRequest()
       request.params.state_json = "{\"tokens\": {\"refresh_token\": \"token\"}}"
-      gaxiosStub.resolves({data: {access_token: "test"}} as any)
+      gaxiosStub.resolves({data: {access_token: "test", refresh_token: "lol"}} as any)
 
       const form = action.validateAndFetchForm(request)
       chai.expect(form).to.eventually.deep.equal({
@@ -185,6 +186,9 @@ describe(`${action.constructor.name} unit tests`, () => {
           required: true,
           type: "string",
         }],
+        state: {
+          data: "{\"tokens\":{\"refresh_token\":\"lol\",\"access_token\":\"test\"}}",
+        },
       }).and.notify(done)
     })
   })


### PR DESCRIPTION
unlike other oauth flows, Airtable uses a chained refresh_token which is reset on every /oauth2/v1/token request. Ensure state is reset in Looker to enable long lived schedules without constant manual reconsent