### PR TITLE
Adds error messages to response object for sendgrid action.

### DIFF
--- a/lib/actions/sendgrid/sendgrid.js
+++ b/lib/actions/sendgrid/sendgrid.js
@@ -32,12 +32,17 @@ class SendGridAction extends Hub.Action {
         this.supportedActionTypes = [Hub.ActionType.Query, Hub.ActionType.Dashboard];
     }
     execute(request) {
+        const response = new Hub.ActionResponse();
         return __awaiter(this, void 0, void 0, function* () {
             if (!request.attachment || !request.attachment.dataBuffer) {
-                throw "Couldn't get data from attachment.";
+                response.success = false;
+                response.message = "Error: could not retrieve data from attachment, or attachment does not exist";
+                return response;
             }
             if (!request.formParams.to) {
-                throw "Needs a valid email address.";
+                response.success = false;
+                response.message = "Error: invalid email address";
+                return response;
             }
             const filename = request.formParams.filename || request.suggestedFilename();
             const plan = request.scheduledPlan;
@@ -60,14 +65,15 @@ class SendGridAction extends Hub.Action {
                         filename,
                     }],
             });
-            let response;
             try {
                 yield this.sendEmail(request, msg);
+                response.success = true;
             }
             catch (e) {
-                response = { success: false, message: e.message };
+                response.success = false;
+                response.message = `Error: ${e.toString()}`;
             }
-            return new Hub.ActionResponse(response);
+            return response;
         });
     }
     sendEmail(request, msg) {

--- a/src/actions/sendgrid/sendgrid.ts
+++ b/src/actions/sendgrid/sendgrid.ts
@@ -66,7 +66,7 @@ export class SendGridAction extends Hub.Action {
       response.success = true
     } catch (e: any) {
       response.success = false
-      response.message = `Error: ${e}`
+      response.message = `Error: ${e.message}`
 
       if (e.response) {
         winston.error(`Failed execute for sendgrid with status code: ${e.response.status}`)

--- a/src/actions/sendgrid/sendgrid.ts
+++ b/src/actions/sendgrid/sendgrid.ts
@@ -66,8 +66,11 @@ export class SendGridAction extends Hub.Action {
       response.success = true
     } catch (e: any) {
       response.success = false
-      response.message = `Error: ${e.toString()}`
-      winston.error(`Failed execute for sendgrid. ${response.message}`)
+      response.message = `Error: ${e}`
+
+      if (e.response) {
+        winston.error(`Failed execute for sendgrid with status code: ${e.response.status}`)
+      }
     }
     return response
   }

--- a/src/actions/sendgrid/sendgrid.ts
+++ b/src/actions/sendgrid/sendgrid.ts
@@ -1,3 +1,4 @@
+import winston = require("winston")
 import * as Hub from "../../hub"
 
 import * as helpers from "@sendgrid/helpers"
@@ -22,13 +23,22 @@ export class SendGridAction extends Hub.Action {
   supportedActionTypes = [Hub.ActionType.Query, Hub.ActionType.Dashboard]
 
   async execute(request: Hub.ActionRequest) {
+    const response = new Hub.ActionResponse()
+
     if (!request.attachment || !request.attachment.dataBuffer) {
-      throw "Couldn't get data from attachment."
+      response.success = false
+      response.message = "Error: could not retrieve data from attachment, or attachment does not exist"
+      winston.error(`Failed execute for sendgrid. ${response.message}`)
+      return response
     }
 
     if (!request.formParams.to) {
-      throw "Needs a valid email address."
+      response.success = false
+      response.message = "Error: invalid email address"
+      winston.error(`Failed execute for sendgrid. ${response.message}`)
+      return response
     }
+
     const filename = request.formParams.filename || request.suggestedFilename()
     const plan = request.scheduledPlan
     const subject = request.formParams.subject || (plan && plan.title ? plan.title : "Looker")
@@ -51,13 +61,15 @@ export class SendGridAction extends Hub.Action {
         filename,
       }],
     })
-    let response
     try {
       await this.sendEmail(request, msg)
+      response.success = true
     } catch (e: any) {
-      response = {success: false, message: e.message}
+      response.success = false
+      response.message = `Error: ${e.toString()}`
+      winston.error(`Failed execute for sendgrid. ${response.message}`)
     }
-    return new Hub.ActionResponse(response)
+    return response
   }
 
   async sendEmail(request: Hub.ActionRequest, msg: helpers.classes.Mail) {

--- a/src/actions/sendgrid/test_sendgrid.ts
+++ b/src/actions/sendgrid/test_sendgrid.ts
@@ -45,11 +45,7 @@ describe(`${action.constructor.name} unit tests`, () => {
           refreshQuery: false,
           success: false,
           message: "Error: invalid email address",
-<<<<<<< HEAD
-          validationErrors: []
-=======
           validationErrors: [],
->>>>>>> 7d69a39 (Adds error messages to response object for sendgrid action.)
         })
     })
 
@@ -64,11 +60,7 @@ describe(`${action.constructor.name} unit tests`, () => {
           refreshQuery: false,
           success: false,
           message: "Error: could not retrieve data from attachment, or attachment does not exist",
-<<<<<<< HEAD
-          validationErrors: []
-=======
           validationErrors: [],
->>>>>>> 7d69a39 (Adds error messages to response object for sendgrid action.)
         })
     })
 

--- a/src/actions/sendgrid/test_sendgrid.ts
+++ b/src/actions/sendgrid/test_sendgrid.ts
@@ -45,7 +45,11 @@ describe(`${action.constructor.name} unit tests`, () => {
           refreshQuery: false,
           success: false,
           message: "Error: invalid email address",
+<<<<<<< HEAD
           validationErrors: []
+=======
+          validationErrors: [],
+>>>>>>> 7d69a39 (Adds error messages to response object for sendgrid action.)
         })
     })
 
@@ -60,7 +64,11 @@ describe(`${action.constructor.name} unit tests`, () => {
           refreshQuery: false,
           success: false,
           message: "Error: could not retrieve data from attachment, or attachment does not exist",
+<<<<<<< HEAD
           validationErrors: []
+=======
+          validationErrors: [],
+>>>>>>> 7d69a39 (Adds error messages to response object for sendgrid action.)
         })
     })
 

--- a/src/actions/sendgrid/test_sendgrid.ts
+++ b/src/actions/sendgrid/test_sendgrid.ts
@@ -41,7 +41,12 @@ describe(`${action.constructor.name} unit tests`, () => {
       request.attachment.dataBuffer = Buffer.from("1,2,3,4", "utf8")
 
       return chai.expect(action.execute(request)).to.eventually
-        .be.rejectedWith("Needs a valid email address.")
+        .deep.equal({
+          refreshQuery: false,
+          success: false,
+          message: "Error: invalid email address",
+          validationErrors: []
+        })
     })
 
     it("errors if the input has no attachment", () => {
@@ -51,7 +56,12 @@ describe(`${action.constructor.name} unit tests`, () => {
       }
 
       return chai.expect(action.execute(request)).to.eventually
-        .be.rejectedWith("Couldn't get data from attachment")
+        .deep.equal({
+          refreshQuery: false,
+          success: false,
+          message: "Error: could not retrieve data from attachment, or attachment does not exist",
+          validationErrors: []
+        })
     })
 
     it("sends right body to filename and address", () => {


### PR DESCRIPTION
Previously we were throwing with an error message but the ActionContainer was not picking up the errors clearly in the logs. This changes that so on error we return the object the container expects with associtated success=false and error message.