### PR TITLE
Refactor airtable token refresh

### DIFF
--- a/lib/actions/airtable/airtable.d.ts
+++ b/lib/actions/airtable/airtable.d.ts
@@ -21,4 +21,5 @@ export declare class AirtableAction extends Hub.OAuthAction {
     oauthUrl(redirectUri: string, encryptedState: string): Promise<string>;
     private airtableClientFromRequest;
     private refreshTokens;
+    private executeAirtable;
 }

--- a/lib/actions/airtable/airtable.js
+++ b/lib/actions/airtable/airtable.js
@@ -61,32 +61,32 @@ class AirtableAction extends Hub.OAuthAction {
                 let accessToken;
                 if (request.params.state_json) {
                     const stateJson = JSON.parse(request.params.state_json);
-                    const refreshResponse = yield this.refreshTokens(stateJson.tokens.refresh_token);
-                    accessToken = refreshResponse.data.access_token;
-                    // Every single access_token invalidates previous refresh_token. Need to
-                    // update state on EVERY request
+                    accessToken = stateJson.tokens.access_token;
                     state.data = JSON.stringify({
                         tokens: {
-                            refresh_token: refreshResponse.data.refresh_token,
+                            refresh_token: stateJson.tokens.refresh_token,
                             access_token: accessToken,
                         },
                     });
                 }
-                const airtableClient = yield this.airtableClientFromRequest(accessToken);
-                const base = airtableClient.base(request.formParams.base);
-                const table = base(request.formParams.table);
-                yield Promise.all(records.map((record) => __awaiter(this, void 0, void 0, function* () {
-                    return new Promise((resolve, reject) => {
-                        table.create(record, (err, rec) => {
-                            if (err) {
-                                reject(err);
-                            }
-                            else {
-                                resolve(rec);
-                            }
+                try {
+                    yield this.executeAirtable(request, records, accessToken);
+                }
+                catch (_a) {
+                    if (request.params.state_json) {
+                        const stateJson = JSON.parse(request.params.state_json);
+                        const refreshResponse = yield this.refreshTokens(stateJson.tokens.refresh_token);
+                        accessToken = refreshResponse.data.access_token;
+                        state.data = JSON.stringify({
+                            tokens: {
+                                refresh_token: refreshResponse.data.refresh_token,
+                                access_token: accessToken,
+                            },
                         });
-                    });
-                })));
+                    }
+                    // Try again one more time with the new access token
+                    yield this.executeAirtable(request, records, accessToken);
+                }
             }
             catch (e) {
                 response.success = false;
@@ -116,17 +116,26 @@ class AirtableAction extends Hub.OAuthAction {
                 let accessToken;
                 if (request.params.state_json) {
                     const stateJson = JSON.parse(request.params.state_json);
-                    const refreshResponse = yield this.refreshTokens(stateJson.tokens.refresh_token);
-                    accessToken = refreshResponse.data.access_token;
-                    // Every single access_token invalidates previous refresh_token. Need to
-                    // update state on EVERY request
-                    form.state = new hub_1.ActionState();
-                    form.state.data = JSON.stringify({ tokens: {
-                            refresh_token: refreshResponse.data.refresh_token,
-                            access_token: accessToken,
-                        } });
+                    accessToken = stateJson.tokens.access_token;
                 }
-                yield this.checkBaseList(accessToken);
+                try {
+                    yield this.checkBaseList(accessToken);
+                }
+                catch (_a) {
+                    // Assume the failure is due to Oauth failure,
+                    // refresh token and retry once.
+                    if (request.params.state_json) {
+                        const stateJson = JSON.parse(request.params.state_json);
+                        const refreshResponse = yield this.refreshTokens(stateJson.tokens.refresh_token);
+                        accessToken = refreshResponse.data.access_token;
+                        form.state = new hub_1.ActionState();
+                        form.state.data = JSON.stringify({ tokens: {
+                                refresh_token: refreshResponse.data.refresh_token,
+                                access_token: accessToken,
+                            } });
+                    }
+                    yield this.checkBaseList(accessToken);
+                }
                 form.fields = [{
                         label: "Airtable Base",
                         name: "base",
@@ -154,6 +163,10 @@ class AirtableAction extends Hub.OAuthAction {
                         type: "oauth_link",
                         oauth_url: `${process.env.ACTION_HUB_BASE_URL}/actions/${this.name}/oauth?state=${ciphertextBlob}`,
                     }];
+            }
+            if (form.state === undefined) {
+                form.state = new hub_1.ActionState();
+                form.state.data = request.params.state_json;
             }
             return form;
         });
@@ -272,6 +285,25 @@ class AirtableAction extends Hub.OAuthAction {
                 winston.warn(errorMessage);
                 return { data: {} };
             }
+        });
+    }
+    executeAirtable(request, records, accessToken) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const airtableClient = yield this.airtableClientFromRequest(accessToken);
+            const base = airtableClient.base(request.formParams.base);
+            const table = base(request.formParams.table);
+            yield Promise.all(records.map((record) => __awaiter(this, void 0, void 0, function* () {
+                return new Promise((resolve, reject) => {
+                    table.create(record, (err, rec) => {
+                        if (err) {
+                            reject(err);
+                        }
+                        else {
+                            resolve(rec);
+                        }
+                    });
+                });
+            })));
         });
     }
 }

--- a/lib/actions/google/gcs/google_cloud_storage.js
+++ b/lib/actions/google/gcs/google_cloud_storage.js
@@ -121,7 +121,7 @@ class GoogleCloudStorageAction extends Hub.Action {
                 response.error = error;
                 response.message = error.message;
                 response.webhookId = request.webhookId;
-                winston.error(`${LOG_PREFIX} ${e.message} ${e}`, { error, webhookId: request.webhookId });
+                winston.error(`${error.message}`, { error, webhookId: request.webhookId });
                 return response;
             }
         });

--- a/src/actions/airtable/airtable.ts
+++ b/src/actions/airtable/airtable.ts
@@ -55,32 +55,27 @@ export class AirtableAction extends Hub.OAuthAction {
       let accessToken
       if (request.params.state_json) {
         const stateJson = JSON.parse(request.params.state_json)
-        const refreshResponse = await this.refreshTokens(stateJson.tokens.refresh_token)
-        accessToken = (refreshResponse as any).data.access_token
-        // Every single access_token invalidates previous refresh_token. Need to
-        // update state on EVERY request
-        state.data = JSON.stringify({
-          tokens: {
-            refresh_token: (refreshResponse as any).data.refresh_token,
-            access_token: accessToken,
-          },
-        })
+        accessToken = stateJson.data.access_token
+        state.data = request.params.state_json
       }
-      const airtableClient = await this.airtableClientFromRequest(accessToken)
-      const base = airtableClient.base(request.formParams.base)
-      const table = base(request.formParams.table)
 
-      await Promise.all(records.map(async (record: any) => {
-        return new Promise<void>((resolve, reject) => {
-          table.create(record, (err: { message: string } | null, rec: any) => {
-            if (err) {
-              reject(err)
-            } else {
-              resolve(rec)
-            }
+      try {
+        await this.executeAirtable(request, records, accessToken)
+      } catch {
+        if (request.params.state_json) {
+          const stateJson = JSON.parse(request.params.state_json)
+          const refreshResponse = await this.refreshTokens(stateJson.tokens.refresh_token)
+          accessToken = (refreshResponse as any).data.access_token
+          state.data = JSON.stringify({
+            tokens: {
+              refresh_token: (refreshResponse as any).data.refresh_token,
+              access_token: accessToken,
+            },
           })
-        })
-      }))
+        }
+        // Try again one more time with the new access token
+        await this.executeAirtable(request, records, accessToken)
+      }
     } catch (e: any) {
       response.success = false
       response.message = e.message
@@ -107,17 +102,25 @@ export class AirtableAction extends Hub.OAuthAction {
       let accessToken
       if (request.params.state_json) {
         const stateJson = JSON.parse(request.params.state_json)
-        const refreshResponse = await this.refreshTokens(stateJson.tokens.refresh_token)
-        accessToken = (refreshResponse as any).data.access_token
-        // Every single access_token invalidates previous refresh_token. Need to
-        // update state on EVERY request
-        form.state = new ActionState()
-        form.state.data = JSON.stringify({tokens: {
-            refresh_token: (refreshResponse as any).data.refresh_token,
-            access_token: accessToken,
-          }})
+        accessToken = stateJson.tokens.access_token
       }
-      await this.checkBaseList(accessToken)
+      try {
+        await this.checkBaseList(accessToken)
+      } catch {
+        // Assume the failure is due to Oauth failure,
+        // refresh token and retry once.
+        if (request.params.state_json) {
+          const stateJson = JSON.parse(request.params.state_json)
+          const refreshResponse = await this.refreshTokens(stateJson.tokens.refresh_token)
+          accessToken = (refreshResponse as any).data.access_token
+          form.state = new ActionState()
+          form.state.data = JSON.stringify({tokens: {
+              refresh_token: (refreshResponse as any).data.refresh_token,
+              access_token: accessToken,
+            }})
+        }
+        await this.checkBaseList(accessToken)
+      }
       form.fields = [{
         label: "Airtable Base",
         name: "base",
@@ -146,6 +149,10 @@ export class AirtableAction extends Hub.OAuthAction {
         type: "oauth_link",
         oauth_url: `${process.env.ACTION_HUB_BASE_URL}/actions/${this.name}/oauth?state=${ciphertextBlob}`,
       }]
+    }
+    if (form.state === undefined) {
+      form.state = new ActionState()
+      form.state.data = request.params.state_json
     }
     return form
   }
@@ -263,6 +270,24 @@ export class AirtableAction extends Hub.OAuthAction {
       winston.warn(errorMessage)
       return {data: {}}
     }
+  }
+
+  private async executeAirtable(request: Hub.ActionRequest, records: any, accessToken: string) {
+    const airtableClient = await this.airtableClientFromRequest(accessToken)
+    const base = airtableClient.base(request.formParams.base)
+    const table = base(request.formParams.table)
+
+    await Promise.all(records.map(async (record: any) => {
+      return new Promise<void>((resolve, reject) => {
+        table.create(record, (err: { message: string } | null, rec: any) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(rec)
+          }
+        })
+      })
+    }))
   }
 
 }

--- a/src/actions/airtable/airtable.ts
+++ b/src/actions/airtable/airtable.ts
@@ -55,8 +55,13 @@ export class AirtableAction extends Hub.OAuthAction {
       let accessToken
       if (request.params.state_json) {
         const stateJson = JSON.parse(request.params.state_json)
-        accessToken = stateJson.data.access_token
-        state.data = request.params.state_json
+        accessToken = stateJson.tokens.access_token
+        state.data = JSON.stringify({
+          tokens: {
+            refresh_token: stateJson.tokens.refresh_token,
+            access_token: accessToken,
+          },
+        })
       }
 
       try {

--- a/src/actions/airtable/test_airtable.ts
+++ b/src/actions/airtable/test_airtable.ts
@@ -76,6 +76,36 @@ describe(`${action.constructor.name} unit tests`, () => {
         .be.rejectedWith("Missing Airtable base or table.")
     })
 
+    it("errors if there is no fields in dataJSON", () => {
+      const request = new Hub.ActionRequest()
+      request.formParams = request.formParams = {
+        base: "mybase",
+        table: "mytable",
+      }
+      request.attachment = {dataJSON: {
+          data: [{"coolview.coolfield": {value: "funvalue"}}],
+        }}
+      return chai.expect(action.execute(request)).to.eventually
+          .be.rejectedWith("Request payload is an invalid format.")
+    })
+
+    it("errors if there is no data in dataJSON", () => {
+      const request = new Hub.ActionRequest()
+      request.formParams = request.formParams = {
+        base: "mybase",
+        table: "mytable",
+      }
+      request.attachment = {dataJSON: {
+          fields: {
+            dimensions: [
+              {name: "coolview.coolfield", label_short: "cool field", tags: ["user_id"]},
+            ],
+          },
+        }}
+      return chai.expect(action.execute(request)).to.eventually
+          .be.rejectedWith("Request payload is an invalid format.")
+    })
+
     it("sends right body", () => {
       const request = new Hub.ActionRequest()
       request.formParams = {
@@ -160,6 +190,26 @@ describe(`${action.constructor.name} unit tests`, () => {
       })
     })
 
+    it("refreshes on oauth failure", () => {
+      const request = new Hub.ActionRequest()
+      request.formParams = {
+        base: "mybase",
+        table: "mytable",
+      }
+      request.attachment = {dataJSON: {
+          fields: {
+            dimensions: [
+              {name: "coolview.coolfield", tags: ["user_id"]},
+            ],
+          },
+          data: [{"coolview.coolfield": {value: "funvalue"}}],
+        }}
+      return expectWebhookMatch(request,
+          request.formParams.base,
+          request.formParams.table,
+          {"coolview.coolfield": "funvalue"})
+    })
+
   })
 
   describe("form", () => {
@@ -170,8 +220,38 @@ describe(`${action.constructor.name} unit tests`, () => {
 
     it("has form with base and table param", (done) => {
       const request = new Hub.ActionRequest()
-      request.params.state_json = "{\"tokens\": {\"refresh_token\": \"token\"}}"
+      request.params.state_json = "{\"tokens\":{\"refresh_token\":\"token\"}}"
       gaxiosStub.resolves({data: {access_token: "test", refresh_token: "lol"}} as any)
+
+      const form = action.validateAndFetchForm(request)
+      chai.expect(form).to.eventually.deep.equal({
+        fields: [{
+          label: "Airtable Base",
+          name: "base",
+          required: true,
+          type: "string",
+        }, {
+          label: "Airtable Table",
+          name: "table",
+          required: true,
+          type: "string",
+        }],
+        state: {
+          data: "{\"tokens\":{\"refresh_token\":\"token\"}}",
+        },
+      }).and.notify(done)
+    })
+
+    it("succeeds after failing oauth once", (done) => {
+      const request = new Hub.ActionRequest()
+      request.params.state_json = "{\"tokens\": {\"refresh_token\": \"token\"}}"
+      gaxiosStub
+          .onCall(0)
+          .throws("oauthTestFailure")
+          .onCall(1)
+          .resolves({data: {access_token: "test", refresh_token: "lol"}} as any)
+          .onCall(2)
+          .resolves({data: "responseToCheckBaseList"})
 
       const form = action.validateAndFetchForm(request)
       chai.expect(form).to.eventually.deep.equal({

--- a/src/actions/airtable/test_airtable.ts
+++ b/src/actions/airtable/test_airtable.ts
@@ -15,6 +15,7 @@ function expectWebhookMatch(
   base: any,
   table: any,
   match: any,
+  resp: any,
 ) {
   const createSpy = sinon.spy((params: any, callback: (err: any, data: any) => void) => {
     callback(null, `successfully sent ${params}`)
@@ -28,11 +29,12 @@ function expectWebhookMatch(
     }))
 
   const execute = action.execute(request)
-  return chai.expect(execute).to.be.fulfilled.then(() => {
+  return chai.expect(execute).to.be.fulfilled.then((result) => {
+    stubPost.restore()
     chai.expect(baseSpy).to.have.been.calledWith(base)
     chai.expect(tableSpy).to.have.been.calledWith(table)
     chai.expect(createSpy).to.have.been.calledWith(match)
-    stubPost.restore()
+    chai.expect(result).to.deep.equal(resp)
   })
 }
 
@@ -108,6 +110,7 @@ describe(`${action.constructor.name} unit tests`, () => {
 
     it("sends right body", () => {
       const request = new Hub.ActionRequest()
+      request.params.state_json = "{\"tokens\": {\"refresh_token\": \"lol\",\"access_token\":\"test\"}}"
       request.formParams = {
         base: "mybase",
         table: "mytable",
@@ -123,11 +126,21 @@ describe(`${action.constructor.name} unit tests`, () => {
       return expectWebhookMatch(request,
         request.formParams.base,
         request.formParams.table,
-        {"coolview.coolfield": "funvalue"})
+        {"coolview.coolfield": "funvalue"},
+          {
+            refreshQuery: false,
+            state: {
+              data: "{\"tokens\":{\"refresh_token\":\"lol\",\"access_token\":\"test\"}}",
+            },
+            success: true,
+            validationErrors: [],
+          },
+      )
     })
 
     it("sends right body with label_short if present", () => {
       const request = new Hub.ActionRequest()
+      request.params.state_json = "{\"tokens\": {\"refresh_token\": \"lol\",\"access_token\":\"test\"}}"
       request.formParams = {
         base: "mybase",
         table: "mytable",
@@ -146,7 +159,16 @@ describe(`${action.constructor.name} unit tests`, () => {
       return expectWebhookMatch(request,
         request.formParams.base,
         request.formParams.table,
-        {"cool field": "funvalue"})
+        {"cool field": "funvalue"},
+          {
+            refreshQuery: false,
+            state: {
+              data: "{\"tokens\":{\"refresh_token\":\"lol\",\"access_token\":\"test\"}}",
+            },
+            success: true,
+            validationErrors: [],
+          },
+      )
     })
 
     it("returns failure on airtable create error", () => {
@@ -196,6 +218,7 @@ describe(`${action.constructor.name} unit tests`, () => {
         base: "mybase",
         table: "mytable",
       }
+      request.params.state_json = "{\"tokens\": {\"refresh_token\": \"lol\",\"access_token\":\"test\"}}"
       request.attachment = {dataJSON: {
           fields: {
             dimensions: [
@@ -207,7 +230,16 @@ describe(`${action.constructor.name} unit tests`, () => {
       return expectWebhookMatch(request,
           request.formParams.base,
           request.formParams.table,
-          {"coolview.coolfield": "funvalue"})
+          {"coolview.coolfield": "funvalue"},
+          {
+            refreshQuery: false,
+            state: {
+              data: "{\"tokens\":{\"refresh_token\":\"lol\",\"access_token\":\"test\"}}",
+            },
+            success: true,
+            validationErrors: [],
+          },
+      )
     })
 
   })


### PR DESCRIPTION
This change will move airtable token refresh to when the attempt to reach airtable fails instead of on each request.

This aligns with the airtable style and should work better and increase availability.