### PR TITLE
Remove state from the response when token refresh fails

### DIFF
--- a/lib/actions/airtable/airtable.js
+++ b/lib/actions/airtable/airtable.js
@@ -76,15 +76,21 @@ class AirtableAction extends Hub.OAuthAction {
                     if (request.params.state_json) {
                         const stateJson = JSON.parse(request.params.state_json);
                         const refreshResponse = yield this.refreshTokens(stateJson.tokens.refresh_token);
-                        accessToken = refreshResponse.data.access_token;
-                        state.data = JSON.stringify({
-                            tokens: {
-                                refresh_token: refreshResponse.data.refresh_token,
-                                access_token: accessToken,
-                            },
-                        });
+                        // @ts-ignore
+                        if (Object.keys(refreshResponse.data).length !== 0) {
+                            accessToken = refreshResponse.data.access_token;
+                            state.data = JSON.stringify({
+                                tokens: {
+                                    refresh_token: refreshResponse.data.refresh_token,
+                                    access_token: accessToken,
+                                },
+                            });
+                        }
+                        else {
+                            delete state.data;
+                        }
                     }
-                    // Try again one more time with the new access token
+                    // Try again one more time
                     yield this.executeAirtable(request, records, accessToken);
                 }
             }
@@ -120,6 +126,10 @@ class AirtableAction extends Hub.OAuthAction {
                 }
                 try {
                     yield this.checkBaseList(accessToken);
+                    if (form.state === undefined) {
+                        form.state = new hub_1.ActionState();
+                        form.state.data = request.params.state_json;
+                    }
                 }
                 catch (_a) {
                     // Assume the failure is due to Oauth failure,
@@ -127,12 +137,14 @@ class AirtableAction extends Hub.OAuthAction {
                     if (request.params.state_json) {
                         const stateJson = JSON.parse(request.params.state_json);
                         const refreshResponse = yield this.refreshTokens(stateJson.tokens.refresh_token);
-                        accessToken = refreshResponse.data.access_token;
-                        form.state = new hub_1.ActionState();
-                        form.state.data = JSON.stringify({ tokens: {
-                                refresh_token: refreshResponse.data.refresh_token,
-                                access_token: accessToken,
-                            } });
+                        if (Object.keys(refreshResponse.data).length !== 0) {
+                            accessToken = refreshResponse.data.access_token;
+                            form.state = new hub_1.ActionState();
+                            form.state.data = JSON.stringify({ tokens: {
+                                    refresh_token: refreshResponse.data.refresh_token,
+                                    access_token: accessToken,
+                                } });
+                        }
                     }
                     yield this.checkBaseList(accessToken);
                 }
@@ -163,10 +175,6 @@ class AirtableAction extends Hub.OAuthAction {
                         type: "oauth_link",
                         oauth_url: `${process.env.ACTION_HUB_BASE_URL}/actions/${this.name}/oauth?state=${ciphertextBlob}`,
                     }];
-            }
-            if (form.state === undefined) {
-                form.state = new hub_1.ActionState();
-                form.state.data = request.params.state_json;
             }
             return form;
         });


### PR DESCRIPTION
This change will stop updating state when token refresh fails so that the state is not update with old and unusable tokens.