### PR TITLE
fix: add relax_column_count to avoid invalid record length error

### DIFF
--- a/lib/actions/google/drive/sheets/google_sheets.js
+++ b/lib/actions/google/drive/sheets/google_sheets.js
@@ -190,6 +190,7 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                             rtrim: true,
                             ltrim: true,
                             bom: true,
+                            relax_column_count: true
                         });
                         // This will not clear formulas or protected regions
                         yield this.retriableClearSheet(spreadsheetId, sheet, sheetId, 0, request.webhookId);

--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -194,6 +194,7 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                         rtrim: true,
                         ltrim: true,
                         bom: true,
+                        relax_column_count: true,
                     })
                     // This will not clear formulas or protected regions
                     await this.retriableClearSheet(spreadsheetId, sheet, sheetId, 0, request.webhookId!)


### PR DESCRIPTION
Change Log:
[ ] Add relax_column_count in the parse's options to tolerate data sets with inconsistent number of fields and avoid invalid record length error
