### PR TITLE
adds more messages to googleErrorType converter

### DIFF
--- a/lib/actions/google/drive/sheets/google_sheets.js
+++ b/lib/actions/google/drive/sheets/google_sheets.js
@@ -190,7 +190,7 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                             rtrim: true,
                             ltrim: true,
                             bom: true,
-                            relax_column_count: true
+                            relax_column_count: true,
                         });
                         // This will not clear formulas or protected regions
                         yield this.retriableClearSheet(spreadsheetId, sheet, sheetId, 0, request.webhookId);

--- a/lib/error_types/utils.js
+++ b/lib/error_types/utils.js
@@ -106,6 +106,15 @@ const getGoogleHttpErrorType = (e) => {
     else if (googleErrorMessage.includes("socket hang up")) {
         httpErrorType = http_errors_1.HTTP_ERROR.internal_connreset;
     }
+    else if (googleErrorMessage.includes("the caller does not have permission")) {
+        httpErrorType = http_errors_1.HTTP_ERROR.permision_denied;
+    }
+    else if (googleErrorMessage.includes("cannot send more than")) {
+        httpErrorType = http_errors_1.HTTP_ERROR.bad_request;
+    }
+    else if (googleErrorMessage.includes("the service is currently unavailable")) {
+        httpErrorType = http_errors_1.HTTP_ERROR.unavailable;
+    }
     else {
         httpErrorType = http_errors_1.HTTP_ERROR.internal;
     }

--- a/src/error_types/utils.ts
+++ b/src/error_types/utils.ts
@@ -91,6 +91,12 @@ const getGoogleHttpErrorType = (e: any) => {
     httpErrorType = HTTP_ERROR.unauthenticated
   } else if (googleErrorMessage.includes("socket hang up")) {
     httpErrorType = HTTP_ERROR.internal_connreset
+  } else if (googleErrorMessage.includes("the caller does not have permission")) {
+    httpErrorType = HTTP_ERROR.permision_denied
+  } else if (googleErrorMessage.includes("cannot send more than")) {
+    httpErrorType = HTTP_ERROR.bad_request
+  } else if (googleErrorMessage.includes("the service is currently unavailable")) {
+    httpErrorType = HTTP_ERROR.unavailable
   } else {
     httpErrorType = HTTP_ERROR.internal
   }


### PR DESCRIPTION
Google returns us error messages but does not include the code or status. For us this means we will return the correct error message but it will be defaulted to a 500 Internal which over inflates our metrics. This is the second pass at trying to categorize the messages to the correct status code. 

These magic strings are taken from the pantheon logs where I look to see if there are any 500 internal errors that are miscatagorized.