### PR TITLE
adds increased error logging to drive form request

### DIFF
--- a/lib/actions/google/drive/google_drive.js
+++ b/lib/actions/google/drive/google_drive.js
@@ -152,7 +152,16 @@ class GoogleDriveAction extends Hub.OAuthAction {
                     }
                 }
                 catch (e) {
-                    winston.error("Can not sign in to Google", { webhookId: request.webhookId });
+                    const errorType = (0, utils_1.getHttpErrorType)(e, this.name);
+                    let error = (0, action_response_1.errorWith)(errorType, `${LOG_PREFIX} ${e.message}`);
+                    let errorObjectKeys;
+                    for (const [key, _] of Object.entries(e)) {
+                        errorObjectKeys.push(key);
+                    }
+                    if (e.code && e.errors && e.errors[0] && e.errors[0].message) {
+                        error = Object.assign(Object.assign({}, error), { http_code: e.code, message: `${errorType.description} ${LOG_PREFIX} ${e.errors[0].message}` });
+                    }
+                    winston.error("Can not sign in to Google", { errorKeys: errorObjectKeys, error, webhookId: request.webhookId });
                 }
             }
             return this.loginForm(request);

--- a/src/actions/google/drive/google_drive.ts
+++ b/src/actions/google/drive/google_drive.ts
@@ -166,7 +166,7 @@ export class GoogleDriveAction extends Hub.OAuthAction {
           errorType,
           `${LOG_PREFIX} ${e.message}`,
         )
-        let errorObjectKeys: any
+        const errorObjectKeys: any = []
         for (const [key, _] of Object.entries(e)) {
           errorObjectKeys.push(key)
         }

--- a/src/actions/google/drive/google_drive.ts
+++ b/src/actions/google/drive/google_drive.ts
@@ -161,7 +161,21 @@ export class GoogleDriveAction extends Hub.OAuthAction {
           return form
         }
       } catch (e: any) {
-        winston.error("Can not sign in to Google", {webhookId: request.webhookId} )
+        const errorType = getHttpErrorType(e, this.name)
+        let error: Error = errorWith(
+          errorType,
+          `${LOG_PREFIX} ${e.message}`,
+        )
+        let errorObjectKeys: any
+        for (const [key, _] of Object.entries(e)) {
+          errorObjectKeys.push(key)
+        }
+        if (e.code && e.errors && e.errors[0] && e.errors[0].message) {
+          error = {
+            ...error, http_code: e.code, message: `${errorType.description} ${LOG_PREFIX} ${e.errors[0].message}`,
+          }
+        }
+        winston.error("Can not sign in to Google", {errorKeys: errorObjectKeys, error, webhookId: request.webhookId} )
       }
     }
     return this.loginForm(request)


### PR DESCRIPTION
This adds error reporting for form requests for Google Drive. We are assuming the error will be the same shape as the execute call but in case it is not, we are adding a list of object keys to the error log as well. 