### PR TITLE
Default to root for Sheets Overwrite

### DIFF
--- a/lib/actions/google/drive/sheets/google_sheets.js
+++ b/lib/actions/google/drive/sheets/google_sheets.js
@@ -24,6 +24,7 @@ const SHEETS_MAX_CELL_LIMIT = 5000000;
 const MAX_RETRY_COUNT = 5;
 const RETRY_BASE_DELAY = process.env.GOOGLE_SHEETS_BASE_DELAY ? Number(process.env.GOOGLE_SHEETS_BASE_DELAY) : 3;
 const LOG_PREFIX = "[GOOGLE_SHEETS]";
+const ROOT = "root";
 const FOLDERID_REGEX = /\/folders\/(?<folderId>[^\/?]+)/;
 class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
     constructor() {
@@ -150,7 +151,7 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
             if (request.formParams.folderid) {
                 winston.info("Using manual folder id");
                 if (request.formParams.folderid.includes("my-drive")) {
-                    folder = "root";
+                    folder = ROOT;
                 }
                 else {
                     const match = request.formParams.folderid.match(FOLDERID_REGEX);
@@ -158,14 +159,14 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                         folder = match.groups.folderId;
                     }
                     else {
-                        folder = "root";
+                        folder = ROOT;
                     }
                 }
             }
             else {
                 folder = request.formParams.folder;
             }
-            const parents = folder ? [folder] : undefined;
+            const parents = folder ? [folder] : ROOT;
             filename = this.sanitizeFilename(filename);
             const options = {
                 q: `name = '${filename}' and '${parents}' in parents and trashed=false`,

--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -18,6 +18,7 @@ const SHEETS_MAX_CELL_LIMIT = 5000000
 const MAX_RETRY_COUNT = 5
 const RETRY_BASE_DELAY = process.env.GOOGLE_SHEETS_BASE_DELAY ? Number(process.env.GOOGLE_SHEETS_BASE_DELAY) : 3
 const LOG_PREFIX = "[GOOGLE_SHEETS]"
+const ROOT = "root"
 const FOLDERID_REGEX = /\/folders\/(?<folderId>[^\/?]+)/
 
 export class GoogleSheetsAction extends GoogleDriveAction {
@@ -151,19 +152,19 @@ export class GoogleSheetsAction extends GoogleDriveAction {
         if (request.formParams.folderid) {
             winston.info("Using manual folder id")
             if (request.formParams.folderid.includes("my-drive")) {
-                folder = "root"
+                folder = ROOT
             } else {
                 const match = request.formParams.folderid.match(FOLDERID_REGEX)
                 if (match && match.groups) {
                     folder = match.groups.folderId
                 } else {
-                    folder = "root"
+                    folder = ROOT
                 }
             }
         } else {
             folder = request.formParams.folder
         }
-        const parents = folder ? [folder] : undefined
+        const parents = folder ? [folder] : ROOT
 
         filename = this.sanitizeFilename(filename)
         const options: any = {


### PR DESCRIPTION
This default will restore previous behavior of no action taken on the google sheet form instead of sending :undefined