### PR TITLE
fix: remove ';base64' from mimeType when is xlsx format

### DIFF
--- a/lib/actions/google/drive/google_drive.js
+++ b/lib/actions/google/drive/google_drive.js
@@ -246,7 +246,10 @@ class GoogleDriveAction extends Hub.OAuthAction {
         return new googleapis_1.google.auth.OAuth2(process.env.GOOGLE_DRIVE_CLIENT_ID, process.env.GOOGLE_DRIVE_CLIENT_SECRET, redirectUri);
     }
     async sendData(filename, request, drive) {
-        const mimeType = this.getMimeType(request);
+        let mimeType = this.getMimeType(request);
+        if ((mimeType === null || mimeType === void 0 ? void 0 : mimeType.includes("spreadsheetml.sheet")) && mimeType.includes(";base64")) {
+            mimeType = mimeType.replace(";base64", "");
+        }
         let folder;
         if (request.formParams.folderid) {
             if (request.formParams.folderid.includes("my-drive")) {

--- a/src/actions/google/drive/google_drive.ts
+++ b/src/actions/google/drive/google_drive.ts
@@ -292,7 +292,10 @@ export class GoogleDriveAction extends Hub.OAuthAction {
   }
 
    async sendData(filename: string, request: Hub.ActionRequest, drive: Drive) {
-     const mimeType = this.getMimeType(request)
+     let mimeType = this.getMimeType(request)
+     if (mimeType?.includes("spreadsheetml.sheet") && mimeType.includes(";base64")) {
+      mimeType = mimeType.replace(";base64", "")
+     }
      let folder: string | undefined
      if (request.formParams.folderid) {
        if (request.formParams.folderid.includes("my-drive")) {


### PR DESCRIPTION
Remove ';base64' from mimeType string when sending in xlsx format so that it does not arrive in zip format