### PR TITLE
Add dynamic resizing for sheets

### DIFF
--- a/lib/actions/google/drive/sheets/google_sheets.js
+++ b/lib/actions/google/drive/sheets/google_sheets.js
@@ -217,7 +217,7 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                     // This will not clear formulas or protected regions
                     await this.retriableClearSheet(spreadsheetId, sheet, sheetId, 0, request.webhookId);
                     // Set the sheet's rows to max rows possible
-                    winston.info(`Setting sheet rows to ${1}`, request.webhookId);
+                    winston.info(`Setting sheet rows to ${INITIAL_RESIZE}`, request.webhookId);
                     await this.retriableResize(INITIAL_RESIZE, sheet, spreadsheetId, sheetId, 0, request.webhookId);
                     csvparser.on("data", (line) => {
                         if (rowCount > maxPossibleRows) {

--- a/lib/actions/google/drive/sheets/google_sheets.js
+++ b/lib/actions/google/drive/sheets/google_sheets.js
@@ -229,7 +229,7 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                             currentMaxRows = Math.min(rowCount + MAX_ROW_BUFFER_INCREASE, maxPossibleRows);
                             winston.info(`Pausing stream and resizing to ${currentMaxRows} rows`, { webhookId: request.webhookId });
                             this.retriableResize(currentMaxRows, sheet, spreadsheetId, sheetId, 0, request.webhookId).then(() => {
-                                winston.info("Resuming");
+                                winston.info("Resuming stream", { webhookId: request.webhookId });
                                 csvparser.resume();
                             }).catch((e) => {
                                 throw e;

--- a/lib/actions/google/drive/sheets/google_sheets.js
+++ b/lib/actions/google/drive/sheets/google_sheets.js
@@ -11,6 +11,8 @@ const hub_1 = require("../../../../hub");
 const google_drive_1 = require("../google_drive");
 const MAX_REQUEST_BATCH = process.env.GOOGLE_SHEETS_WRITE_BATCH ? Number(process.env.GOOGLE_SHEETS_WRITE_BATCH) : 4096;
 const SHEETS_MAX_CELL_LIMIT = 5000000;
+const MAX_ROW_BUFFER_INCREASE = 6000;
+const INITIAL_RESIZE = 6000;
 const MAX_RETRY_COUNT = 5;
 const RETRY_BASE_DELAY = process.env.GOOGLE_SHEETS_BASE_DELAY ? Number(process.env.GOOGLE_SHEETS_BASE_DELAY) : 3;
 const LOG_PREFIX = "[GOOGLE_SHEETS]";
@@ -197,6 +199,7 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
         // The ignore is here because Typescript is not correctly inferring that I have done existence checks
         const sheetId = sheets.data.sheets[0].properties.sheetId;
         const columns = sheets.data.sheets[0].properties.gridProperties.columnCount;
+        let currentMaxRows = sheets.data.sheets[0].properties.gridProperties.rowCount;
         const maxPossibleRows = Math.floor(SHEETS_MAX_CELL_LIMIT / columns);
         const requestBody = { requests: [] };
         let rowCount = 0;
@@ -214,13 +217,24 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                     // This will not clear formulas or protected regions
                     await this.retriableClearSheet(spreadsheetId, sheet, sheetId, 0, request.webhookId);
                     // Set the sheet's rows to max rows possible
-                    winston.info(`Expanding sheet rows to ${maxPossibleRows}`, request.webhookId);
-                    await this.retriableResize(maxPossibleRows, sheet, spreadsheetId, sheetId, 0, request.webhookId);
+                    winston.info(`Setting sheet rows to ${1}`, request.webhookId);
+                    await this.retriableResize(INITIAL_RESIZE, sheet, spreadsheetId, sheetId, 0, request.webhookId);
                     csvparser.on("data", (line) => {
                         if (rowCount > maxPossibleRows) {
                             reject(`Cannot send more than ${maxPossibleRows} without exceeding limit of 5 million cells in Google Sheets`);
                         }
                         const rowIndex = rowCount++;
+                        if (rowIndex >= currentMaxRows - 1) {
+                            csvparser.pause();
+                            currentMaxRows = Math.min(rowCount + MAX_ROW_BUFFER_INCREASE, maxPossibleRows);
+                            winston.info(`Pausing stream and resizing to ${currentMaxRows} rows`, { webhookId: request.webhookId });
+                            this.retriableResize(currentMaxRows, sheet, spreadsheetId, sheetId, 0, request.webhookId).then(() => {
+                                winston.info("Resuming");
+                                csvparser.resume();
+                            }).catch((e) => {
+                                throw e;
+                            });
+                        }
                         // Sanitize line data and properly encapsulate string formatting for CSV lines
                         const lineData = line.map((record) => {
                             record = record.replace(/\"/g, "\"\"");

--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -243,7 +243,7 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                   await this.retriableClearSheet(spreadsheetId, sheet, sheetId, 0, request.webhookId!)
 
                   // Set the sheet's rows to max rows possible
-                  winston.info(`Setting sheet rows to ${1}`, request.webhookId)
+                  winston.info(`Setting sheet rows to ${INITIAL_RESIZE}`, request.webhookId)
                   await this.retriableResize(
                     INITIAL_RESIZE,
                     sheet,

--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -271,7 +271,7 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                               0,
                               request.webhookId!,
                           ).then(() => {
-                              winston.info("Resuming")
+                              winston.info("Resuming stream", {webhookId: request.webhookId})
                               csvparser.resume()
                           }).catch((e: any) => {
                               throw e


### PR DESCRIPTION
Resizing now is dynamic in blocks of 6000 rows. Enabled via pausing the csv-parser transform stream while resizing takes place. If resizing fails then fail the execution