### PR TITLE
Phillip/revert sync changes

### DIFF
--- a/lib/actions/google/drive/sheets/google_sheets.js
+++ b/lib/actions/google/drive/sheets/google_sheets.js
@@ -199,7 +199,7 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
         // The ignore is here because Typescript is not correctly inferring that I have done existence checks
         const sheetId = sheets.data.sheets[0].properties.sheetId;
         const columns = sheets.data.sheets[0].properties.gridProperties.columnCount;
-        let currentMaxRows = INITIAL_RESIZE;
+        let currentMaxRows = sheets.data.sheets[0].properties.gridProperties.rowCount;
         const maxPossibleRows = Math.floor(SHEETS_MAX_CELL_LIMIT / columns);
         const requestBody = { requests: [] };
         let rowCount = 0;
@@ -219,55 +219,52 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                     // Set the sheet's rows to max rows possible
                     winston.info(`Setting sheet rows to ${INITIAL_RESIZE}`, request.webhookId);
                     await this.retriableResize(INITIAL_RESIZE, sheet, spreadsheetId, sheetId, 0, request.webhookId);
-                    let line;
-                    csvparser.on("readable", async () => {
-                        line = csvparser.read();
-                        while (line !== null) {
-                            if (rowCount > maxPossibleRows) {
-                                reject(`Cannot send more than ${maxPossibleRows} without exceeding limit of 5 million cells in Google Sheets`);
-                            }
-                            const rowIndex = rowCount++;
-                            if (rowIndex >= currentMaxRows - 1) {
-                                currentMaxRows = Math.min(rowCount + MAX_ROW_BUFFER_INCREASE, maxPossibleRows);
-                                winston.info(`Pausing stream and resizing to ${currentMaxRows} rows`, { webhookId: request.webhookId });
-                                await this.retriableResize(currentMaxRows, sheet, spreadsheetId, sheetId, 0, request.webhookId).then(() => {
-                                    winston.info("Resuming stream", { webhookId: request.webhookId });
-                                }).catch((e) => {
-                                    throw e;
-                                });
-                            }
-                            // Sanitize line data and properly encapsulate string formatting for CSV lines
-                            const lineData = line.map((record) => {
-                                record = record.replace(/\"/g, "\"\"");
-                                return `"${record}"`;
-                            }).join(",");
-                            // @ts-ignore
-                            requestBody.requests.push({
-                                pasteData: {
-                                    coordinate: {
-                                        sheetId,
-                                        columnIndex: 0,
-                                        rowIndex,
-                                    },
-                                    data: lineData,
-                                    delimiter: ",",
-                                    type: "PASTE_NORMAL",
-                                },
+                    csvparser.on("data", (line) => {
+                        if (rowCount > maxPossibleRows) {
+                            reject(`Cannot send more than ${maxPossibleRows} without exceeding limit of 5 million cells in Google Sheets`);
+                        }
+                        const rowIndex = rowCount++;
+                        if (rowIndex >= currentMaxRows - 1) {
+                            csvparser.pause();
+                            currentMaxRows = Math.min(rowCount + MAX_ROW_BUFFER_INCREASE, maxPossibleRows);
+                            winston.info(`Pausing stream and resizing to ${currentMaxRows} rows`, { webhookId: request.webhookId });
+                            this.retriableResize(currentMaxRows, sheet, spreadsheetId, sheetId, 0, request.webhookId).then(() => {
+                                winston.info("Resuming stream", { webhookId: request.webhookId });
+                                csvparser.resume();
+                            }).catch((e) => {
+                                throw e;
                             });
-                            // @ts-ignore
-                            if (requestBody.requests.length > MAX_REQUEST_BATCH) {
-                                const requestCopy = {};
-                                // Make sure to do a deep copy of the request
-                                Object.assign(requestCopy, requestBody);
-                                requestBody.requests = [];
-                                promiseArray.push(this.flush(requestCopy, sheet, spreadsheetId, request.webhookId)
-                                    .catch((e) => {
-                                    this.sanitizeGaxiosError(e);
-                                    winston.debug(e, { webhookId: request.webhookId });
-                                    throw e;
-                                }));
-                            }
-                            line = csvparser.read();
+                        }
+                        // Sanitize line data and properly encapsulate string formatting for CSV lines
+                        const lineData = line.map((record) => {
+                            record = record.replace(/\"/g, "\"\"");
+                            return `"${record}"`;
+                        }).join(",");
+                        // @ts-ignore
+                        requestBody.requests.push({
+                            pasteData: {
+                                coordinate: {
+                                    sheetId,
+                                    columnIndex: 0,
+                                    rowIndex,
+                                },
+                                data: lineData,
+                                delimiter: ",",
+                                type: "PASTE_NORMAL",
+                            },
+                        });
+                        // @ts-ignore
+                        if (requestBody.requests.length > MAX_REQUEST_BATCH) {
+                            const requestCopy = {};
+                            // Make sure to do a deep copy of the request
+                            Object.assign(requestCopy, requestBody);
+                            requestBody.requests = [];
+                            promiseArray.push(this.flush(requestCopy, sheet, spreadsheetId, request.webhookId)
+                                .catch((e) => {
+                                this.sanitizeGaxiosError(e);
+                                winston.debug(e, { webhookId: request.webhookId });
+                                throw e;
+                            }));
                         }
                     }).on("end", () => {
                         finished = true;

--- a/lib/actions/google/drive/sheets/google_sheets.js
+++ b/lib/actions/google/drive/sheets/google_sheets.js
@@ -12,7 +12,6 @@ const google_drive_1 = require("../google_drive");
 const MAX_REQUEST_BATCH = process.env.GOOGLE_SHEETS_WRITE_BATCH ? Number(process.env.GOOGLE_SHEETS_WRITE_BATCH) : 4096;
 const SHEETS_MAX_CELL_LIMIT = 5000000;
 const MAX_ROW_BUFFER_INCREASE = 6000;
-const INITIAL_RESIZE = 6000;
 const MAX_RETRY_COUNT = 5;
 const RETRY_BASE_DELAY = process.env.GOOGLE_SHEETS_BASE_DELAY ? Number(process.env.GOOGLE_SHEETS_BASE_DELAY) : 3;
 const LOG_PREFIX = "[GOOGLE_SHEETS]";
@@ -216,9 +215,6 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                     });
                     // This will not clear formulas or protected regions
                     await this.retriableClearSheet(spreadsheetId, sheet, sheetId, 0, request.webhookId);
-                    // Set the sheet's rows to max rows possible
-                    winston.info(`Setting sheet rows to ${INITIAL_RESIZE}`, request.webhookId);
-                    await this.retriableResize(INITIAL_RESIZE, sheet, spreadsheetId, sheetId, 0, request.webhookId);
                     csvparser.on("data", (line) => {
                         if (rowCount > maxPossibleRows) {
                             reject(`Cannot send more than ${maxPossibleRows} without exceeding limit of 5 million cells in Google Sheets`);

--- a/lib/actions/google/drive/sheets/google_sheets.js
+++ b/lib/actions/google/drive/sheets/google_sheets.js
@@ -203,6 +203,7 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
         const maxPossibleRows = Math.floor(SHEETS_MAX_CELL_LIMIT / columns);
         const requestBody = { requests: [] };
         let rowCount = 0;
+        let finished = false;
         return request.stream(async (readable) => {
             return new Promise(async (resolve, reject) => {
                 try {
@@ -218,7 +219,7 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                     // Set the sheet's rows to max rows possible
                     winston.info(`Setting sheet rows to ${INITIAL_RESIZE}`, request.webhookId);
                     await this.retriableResize(INITIAL_RESIZE, sheet, spreadsheetId, sheetId, 0, request.webhookId);
-                    let line = null;
+                    let line;
                     csvparser.on("readable", async () => {
                         line = csvparser.read();
                         while (line !== null) {
@@ -267,34 +268,34 @@ class GoogleSheetsAction extends google_drive_1.GoogleDriveAction {
                                 }));
                             }
                             line = csvparser.read();
-                            if (line === null) {
-                                winston.info("Sheets line was empty, ending stream and sending final flush");
-                                if (requestBody.requests && requestBody.requests.length >= 1) {
-                                    const requestCopy = {};
-                                    // Make sure to do a deep copy of the request
-                                    Object.assign(requestCopy, requestBody);
-                                    requestBody.requests = [];
-                                    promiseArray.push(this.flush(requestCopy, sheet, spreadsheetId, request.webhookId)
-                                        .catch((e) => {
-                                        this.sanitizeGaxiosError(e);
-                                        winston.debug(e, { webhookId: request.webhookId });
-                                        throw e;
-                                    }));
-                                }
-                                break;
-                            }
                         }
                     }).on("end", () => {
+                        finished = true;
+                        // @ts-ignore
+                        if (requestBody.requests.length > 0) {
+                            // Write any remaining rows to the sheet
+                            promiseArray.push(this.flush(requestBody, sheet, spreadsheetId, request.webhookId)
+                                .catch((e) => {
+                                this.sanitizeGaxiosError(e);
+                                winston.debug(e, { webhookId: request.webhookId });
+                                throw e;
+                            }));
+                        }
                         Promise.all(promiseArray).then(() => {
-                            resolve();
                             winston.info(`Google Sheets Streamed ${rowCount} rows including headers`, { webhookId: request.webhookId });
+                            resolve();
                         }).catch((e) => {
-                            winston.warn("Await flushes failed.", { webhookId: request.webhookId });
+                            winston.warn("Flush failed.", { webhookId: request.webhookId });
                             reject(e);
                         });
                     }).on("error", (e) => {
                         winston.debug(e, { webhookId: request.webhookId });
                         reject(e);
+                    }).on("close", () => {
+                        if (!finished) {
+                            winston.warn(`Google Sheets Streaming closed socket before "end" event stream.`, { webhookId: request.webhookId });
+                            reject(`"end" event not called before finishing stream`);
+                        }
                     });
                     readable.pipe(csvparser);
                 }

--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -13,7 +13,6 @@ import Drive = drive_v3.Drive
 import Sheet = sheets_v4.Sheets
 
 const MAX_REQUEST_BATCH = process.env.GOOGLE_SHEETS_WRITE_BATCH ? Number(process.env.GOOGLE_SHEETS_WRITE_BATCH) : 4096
-
 const SHEETS_MAX_CELL_LIMIT = 5000000
 const MAX_ROW_BUFFER_INCREASE = 6000
 const INITIAL_RESIZE = 6000
@@ -223,7 +222,7 @@ export class GoogleSheetsAction extends GoogleDriveAction {
         // The ignore is here because Typescript is not correctly inferring that I have done existence checks
         const sheetId = sheets.data.sheets[0].properties.sheetId as number
         const columns = sheets.data.sheets[0].properties.gridProperties.columnCount as number
-        let  currentMaxRows = INITIAL_RESIZE
+        let  currentMaxRows = sheets.data.sheets[0].properties.gridProperties.rowCount as number
         const maxPossibleRows = Math.floor(SHEETS_MAX_CELL_LIMIT / columns)
         const requestBody: sheets_v4.Schema$BatchUpdateSpreadsheetRequest = {requests: []}
         let rowCount = 0
@@ -253,66 +252,63 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                     0,
                     request.webhookId!,
                   )
-                  let line: any
 
-                  csvparser.on("readable", async () => {
-                      line = csvparser.read()
-                      while (line !== null) {
-                          if (rowCount > maxPossibleRows) {
-                              reject(`Cannot send more than ${maxPossibleRows} without exceeding limit of 5 million cells in Google Sheets`)
-                          }
-                          const rowIndex: number = rowCount++
-                          if (rowIndex >= currentMaxRows - 1) {
-                              currentMaxRows = Math.min(rowCount + MAX_ROW_BUFFER_INCREASE, maxPossibleRows)
-                              winston.info(`Pausing stream and resizing to ${currentMaxRows} rows`,
-                                  {webhookId: request.webhookId})
-                              await this.retriableResize(
-                                  currentMaxRows,
-                                  sheet,
-                                  spreadsheetId,
-                                  sheetId,
-                                  0,
-                                  request.webhookId!,
-                              ).then(() => {
-                                  winston.info("Resuming stream", {webhookId: request.webhookId})
-                              }).catch((e: any) => {
-                                  throw e
-                              })
-                          }
-                          // Sanitize line data and properly encapsulate string formatting for CSV lines
-                          const lineData = line.map((record: string) => {
-                              record = record.replace(/\"/g, "\"\"")
-                              return `"${record}"`
-                          }).join(",") as string
-                          // @ts-ignore
-                          requestBody.requests.push({
-                              pasteData: {
-                                  coordinate: {
-                                      sheetId,
-                                      columnIndex: 0,
-                                      rowIndex,
-                                  },
-                                  data: lineData,
-                                  delimiter: ",",
-                                  type: "PASTE_NORMAL",
-                              },
+                  csvparser.on("data", (line: any) => {
+                      if (rowCount > maxPossibleRows) {
+                          reject(`Cannot send more than ${maxPossibleRows} without exceeding limit of 5 million cells in Google Sheets`)
+                      }
+                      const rowIndex: number = rowCount++
+                      if (rowIndex >= currentMaxRows - 1) {
+                          csvparser.pause()
+                          currentMaxRows = Math.min(rowCount + MAX_ROW_BUFFER_INCREASE, maxPossibleRows)
+                          winston.info(`Pausing stream and resizing to ${currentMaxRows} rows`,
+                              {webhookId: request.webhookId})
+                          this.retriableResize(
+                              currentMaxRows,
+                              sheet,
+                              spreadsheetId,
+                              sheetId,
+                              0,
+                              request.webhookId!,
+                          ).then(() => {
+                              winston.info("Resuming stream", {webhookId: request.webhookId})
+                              csvparser.resume()
+                          }).catch((e: any) => {
+                              throw e
                           })
-                          // @ts-ignore
-                          if (requestBody.requests.length > MAX_REQUEST_BATCH) {
-                              const requestCopy: sheets_v4.Schema$BatchUpdateSpreadsheetRequest = {}
-                              // Make sure to do a deep copy of the request
-                              Object.assign(requestCopy, requestBody)
-                              requestBody.requests = []
-                              promiseArray.push(
-                                  this.flush(requestCopy, sheet, spreadsheetId, request.webhookId!)
-                                      .catch((e: any) => {
-                                          this.sanitizeGaxiosError(e)
-                                          winston.debug(e, {webhookId: request.webhookId})
-                                          throw e
-                                      }),
-                              )
-                          }
-                          line = csvparser.read()
+                      }
+                      // Sanitize line data and properly encapsulate string formatting for CSV lines
+                      const lineData = line.map((record: string) => {
+                          record = record.replace(/\"/g, "\"\"")
+                          return `"${record}"`
+                      }).join(",") as string
+                      // @ts-ignore
+                      requestBody.requests.push({
+                          pasteData: {
+                              coordinate: {
+                                  sheetId,
+                                  columnIndex: 0,
+                                  rowIndex,
+                              },
+                              data: lineData,
+                              delimiter: ",",
+                              type: "PASTE_NORMAL",
+                          },
+                      })
+                      // @ts-ignore
+                      if (requestBody.requests.length > MAX_REQUEST_BATCH) {
+                          const requestCopy: sheets_v4.Schema$BatchUpdateSpreadsheetRequest = {}
+                          // Make sure to do a deep copy of the request
+                          Object.assign(requestCopy, requestBody)
+                          requestBody.requests = []
+                          promiseArray.push(
+                            this.flush(requestCopy, sheet, spreadsheetId, request.webhookId!)
+                                .catch((e: any) => {
+                                    this.sanitizeGaxiosError(e)
+                                    winston.debug(e, {webhookId: request.webhookId})
+                                    throw e
+                                }),
+                          )
                       }
                   }).on("end", () => {
                     finished = true

--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -227,6 +227,7 @@ export class GoogleSheetsAction extends GoogleDriveAction {
         const maxPossibleRows = Math.floor(SHEETS_MAX_CELL_LIMIT / columns)
         const requestBody: sheets_v4.Schema$BatchUpdateSpreadsheetRequest = {requests: []}
         let rowCount = 0
+        let finished = false
 
         return request.stream(async (readable) => {
           return new Promise<void>(async (resolve, reject) => {
@@ -252,7 +253,7 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                     0,
                     request.webhookId!,
                   )
-                  let line: any = null
+                  let line: any
 
                   csvparser.on("readable", async () => {
                       line = csvparser.read()
@@ -312,38 +313,40 @@ export class GoogleSheetsAction extends GoogleDriveAction {
                               )
                           }
                           line = csvparser.read()
-                          if (line === null) {
-                              winston.info("Sheets line was empty, ending stream and sending final flush")
-                              if ( requestBody.requests && requestBody.requests.length >= 1) {
-                                  const requestCopy: sheets_v4.Schema$BatchUpdateSpreadsheetRequest = {}
-                                  // Make sure to do a deep copy of the request
-                                  Object.assign(requestCopy, requestBody)
-                                  requestBody.requests = []
-                                  promiseArray.push(
-                                      this.flush(requestCopy, sheet, spreadsheetId, request.webhookId!)
-                                          .catch((e: any) => {
-                                              this.sanitizeGaxiosError(e)
-                                              winston.debug(e, {webhookId: request.webhookId})
-                                              throw e
-                                          }),
-                                  )
-                              }
-                              break
-                          }
                       }
                   }).on("end", () => {
-                      Promise.all(promiseArray).then(() => {
-                          resolve()
-                          winston.info(`Google Sheets Streamed ${rowCount} rows including headers`,
-                              {webhookId: request.webhookId})
-                      }).catch((e: any) => {
-                          winston.warn("Await flushes failed.",
-                              {webhookId: request.webhookId})
-                          reject(e)
-                      })
+                    finished = true
+                    // @ts-ignore
+                    if (requestBody.requests.length > 0) {
+                        // Write any remaining rows to the sheet
+                        promiseArray.push(
+                            this.flush(requestBody, sheet, spreadsheetId, request.webhookId!)
+                                .catch((e: any) => {
+                                    this.sanitizeGaxiosError(e)
+                                    winston.debug(e, {webhookId: request.webhookId})
+                                    throw e
+                                }),
+                        )
+
+                    }
+                    Promise.all(promiseArray).then(() => {
+                        winston.info(`Google Sheets Streamed ${rowCount} rows including headers`,
+                                     {webhookId: request.webhookId})
+                        resolve()
+                    }).catch((e: any) => {
+                        winston.warn("Flush failed.",
+                                     {webhookId: request.webhookId})
+                        reject(e)
+                    })
                   }).on("error", (e: any) => {
                       winston.debug(e, {webhookId: request.webhookId})
                       reject(e)
+                  }).on("close", () => {
+                      if (!finished) {
+                          winston.warn(`Google Sheets Streaming closed socket before "end" event stream.`,
+                                       {webhookId: request.webhookId})
+                          reject(`"end" event not called before finishing stream`)
+                      }
                   })
 
                   readable.pipe(csvparser)

--- a/src/actions/google/drive/sheets/google_sheets.ts
+++ b/src/actions/google/drive/sheets/google_sheets.ts
@@ -15,7 +15,6 @@ import Sheet = sheets_v4.Sheets
 const MAX_REQUEST_BATCH = process.env.GOOGLE_SHEETS_WRITE_BATCH ? Number(process.env.GOOGLE_SHEETS_WRITE_BATCH) : 4096
 const SHEETS_MAX_CELL_LIMIT = 5000000
 const MAX_ROW_BUFFER_INCREASE = 6000
-const INITIAL_RESIZE = 6000
 const MAX_RETRY_COUNT = 5
 const RETRY_BASE_DELAY = process.env.GOOGLE_SHEETS_BASE_DELAY ? Number(process.env.GOOGLE_SHEETS_BASE_DELAY) : 3
 const LOG_PREFIX = "[GOOGLE_SHEETS]"
@@ -241,17 +240,6 @@ export class GoogleSheetsAction extends GoogleDriveAction {
 
                   // This will not clear formulas or protected regions
                   await this.retriableClearSheet(spreadsheetId, sheet, sheetId, 0, request.webhookId!)
-
-                  // Set the sheet's rows to max rows possible
-                  winston.info(`Setting sheet rows to ${INITIAL_RESIZE}`, request.webhookId)
-                  await this.retriableResize(
-                    INITIAL_RESIZE,
-                    sheet,
-                    spreadsheetId,
-                    sheetId,
-                    0,
-                    request.webhookId!,
-                  )
 
                   csvparser.on("data", (line: any) => {
                       if (rowCount > maxPossibleRows) {


### PR DESCRIPTION
Reverting sync streaming changes as it introduced issues on large uploads and stream ending races.
Reverted to "data" event streaming which is row by row and using pause/resume logic in the sync callback.
Removing initial_resize to reduce resize operations on very large uploads