### PR TITLE
Slack migration from v1 upload

### DIFF
--- a/lib/actions/slack/utils.js
+++ b/lib/actions/slack/utils.js
@@ -116,20 +116,6 @@ const getDisplayedFormFields = async (slack, channelType) => {
     return response;
 };
 exports.getDisplayedFormFields = getDisplayedFormFields;
-const convertUMTokens = async (channel, slack) => {
-    var _a;
-    winston.info(`Converting token ${channel}`);
-    const openResponse = await slack.conversations.open({ users: channel });
-    if (openResponse.error) {
-        throw openResponse.error;
-    }
-    else if (!((_a = openResponse === null || openResponse === void 0 ? void 0 : openResponse.channel) === null || _a === void 0 ? void 0 : _a.id)) {
-        throw "No channel ID found";
-    }
-    else {
-        return openResponse.channel.id;
-    }
-};
 const handleExecute = async (request, slack) => {
     const response = new Hub.ActionResponse({ success: true });
     if (!request.formParams.channel) {
@@ -145,8 +131,7 @@ const handleExecute = async (request, slack) => {
     const fileName = request.formParams.filename ? request.completeFilename() : request.suggestedFilename();
     try {
         const isUserToken = request.formParams.channel.startsWith("U") || request.formParams.channel.startsWith("W");
-        const channel = isUserToken ?
-            await convertUMTokens(request.formParams.channel, slack) : request.formParams.channel;
+        const channel = request.formParams.channel;
         if (!request.empty()) {
             const buffs = [];
             await request.stream(async (readable) => {
@@ -177,27 +162,60 @@ const handleExecute = async (request, slack) => {
                         });
                         // Finalize upload and give metadata for channel, title and
                         // comment for the file to be posted.
-                        await slack.files.completeUploadExternal({
-                            files: [{
-                                    id: res.file_id ? res.file_id : "",
-                                    title: fileName,
-                                }],
-                            channel_id: channel,
-                        }).catch((e) => {
-                            winston.error(`${LOG_PREFIX} ${e.message}`, { webhookId });
-                            reject(e);
-                        });
-                        // Workaround for regression in V2 upload, the initial
-                        // comment does not support markdown formatting, breaking
-                        // customer links
-                        if (comment !== "") {
-                            await slack.chat.postMessage({
-                                channel: request.formParams.channel,
-                                text: comment,
+                        if (isUserToken) {
+                            //  If we have a user token, we need to convert the
+                            //  UXXXXX token into a DXXXXX token. Conversations.open()
+                            //  requires channels:manage and extra *:write scopes
+                            //  which will break existing schedules. Posting a message
+                            //  first only requires chat:write which we already have.
+                            //  the response returns a DXXXX token which we can use
+                            //  to upload to the channel
+                            const postResponse = await slack.chat.postMessage({
+                                channel,
+                                text: comment.length !== 0 ? comment : "Looker Data",
+                            }).catch((e) => {
+                                winston.error("Issue posting message", { webhookId });
+                                reject(e);
+                            });
+                            const directChannel = postResponse === null || postResponse === void 0 ? void 0 : postResponse.channel;
+                            const resp2 = await slack.files.completeUploadExternal({
+                                files: [{
+                                        id: res.file_id ? res.file_id : "",
+                                        title: fileName,
+                                    }],
+                                channel_id: directChannel,
                             }).catch((e) => {
                                 winston.error(`${LOG_PREFIX} ${e.message}`, { webhookId });
                                 reject(e);
                             });
+                            winston.info(`response complete : ${JSON.stringify(resp2)}`);
+                            // Workaround for regression in V2 upload, the initial
+                            // comment does not support markdown formatting, breaking
+                            // customer links
+                        }
+                        else {
+                            await slack.files.completeUploadExternal({
+                                files: [{
+                                        id: res.file_id ? res.file_id : "",
+                                        title: fileName,
+                                    }],
+                                channel_id: channel,
+                            }).catch((e) => {
+                                winston.error(`${LOG_PREFIX} ${e.message}`, { webhookId });
+                                reject(e);
+                            });
+                            // Workaround for regression in V2 upload, the initial
+                            // comment does not support markdown formatting, breaking
+                            // customer links
+                            if (comment !== "") {
+                                await slack.chat.postMessage({
+                                    channel,
+                                    text: comment,
+                                }).catch((e) => {
+                                    winston.error(`${LOG_PREFIX} ${e.message}`, { webhookId });
+                                    reject(e);
+                                });
+                            }
                         }
                         resolve();
                     });

--- a/lib/actions/slack/utils.js
+++ b/lib/actions/slack/utils.js
@@ -118,7 +118,8 @@ const getDisplayedFormFields = async (slack, channelType) => {
 exports.getDisplayedFormFields = getDisplayedFormFields;
 const convertUMTokens = async (channel, slack) => {
     var _a;
-    const openResponse = await slack.conversations.open({ channel: channel });
+    winston.info(`Converting token ${channel}`);
+    const openResponse = await slack.conversations.open({ users: channel });
     if (openResponse.error) {
         throw openResponse.error;
     }
@@ -162,9 +163,6 @@ const handleExecute = async (request, slack) => {
                         const buffer = Buffer.concat(buffs);
                         const comment = request.formParams.initial_comment ? request.formParams.initial_comment : "";
                         winston.info(`${LOG_PREFIX} Attempting to send ${buffer.byteLength} bytes to Slack`, { webhookId });
-                        // Unfortunately UploadV2 does not provide a way to upload files
-                        // to user tokens which are common in Looker schedules
-                        // (UXXXXXXX)
                         winston.info(`${LOG_PREFIX} V2 Upload of file`, { webhookId });
                         const res = await slack.files.getUploadURLExternal({
                             filename: fileName,

--- a/lib/actions/slack/utils.js
+++ b/lib/actions/slack/utils.js
@@ -116,6 +116,19 @@ const getDisplayedFormFields = async (slack, channelType) => {
     return response;
 };
 exports.getDisplayedFormFields = getDisplayedFormFields;
+const convertUMTokens = async (channel, slack) => {
+    var _a;
+    const openResponse = await slack.conversations.open({ channel: channel });
+    if (openResponse.error) {
+        throw openResponse.error;
+    }
+    else if (!((_a = openResponse === null || openResponse === void 0 ? void 0 : openResponse.channel) === null || _a === void 0 ? void 0 : _a.id)) {
+        throw "No channel ID found";
+    }
+    else {
+        return openResponse.channel.id;
+    }
+};
 const handleExecute = async (request, slack) => {
     const response = new Hub.ActionResponse({ success: true });
     if (!request.formParams.channel) {
@@ -131,7 +144,8 @@ const handleExecute = async (request, slack) => {
     const fileName = request.formParams.filename ? request.completeFilename() : request.suggestedFilename();
     try {
         const isUserToken = request.formParams.channel.startsWith("U") || request.formParams.channel.startsWith("W");
-        const forceV1Upload = process.env.FORCE_V1_UPLOAD;
+        const channel = isUserToken ?
+            await convertUMTokens(request.formParams.channel, slack) : request.formParams.channel;
         if (!request.empty()) {
             const buffs = [];
             await request.stream(async (readable) => {
@@ -151,52 +165,41 @@ const handleExecute = async (request, slack) => {
                         // Unfortunately UploadV2 does not provide a way to upload files
                         // to user tokens which are common in Looker schedules
                         // (UXXXXXXX)
-                        if (isUserToken || forceV1Upload) {
-                            winston.info(`${LOG_PREFIX} V1 Upload of file`, { webhookId });
-                            await slack.files.upload({
-                                file: buffer,
-                                filename: fileName,
-                                channels: request.formParams.channel,
-                                initial_comment: comment,
-                            });
-                        }
-                        else {
-                            winston.info(`${LOG_PREFIX} V2 Upload of file`, { webhookId });
-                            const res = await slack.files.getUploadURLExternal({
-                                filename: fileName,
-                                length: buffer.byteLength,
-                            });
-                            const upload_url = res.upload_url;
-                            // Upload file to Slack
-                            await gaxios.request({
-                                method: "POST",
-                                url: upload_url,
-                                data: buffer,
-                            });
-                            // Finalize upload and give metadata for channel, title and
-                            // comment for the file to be posted.
-                            await slack.files.completeUploadExternal({
-                                files: [{
-                                        id: res.file_id ? res.file_id : "",
-                                        title: fileName,
-                                    }],
-                                channel_id: request.formParams.channel,
+                        winston.info(`${LOG_PREFIX} V2 Upload of file`, { webhookId });
+                        const res = await slack.files.getUploadURLExternal({
+                            filename: fileName,
+                            length: buffer.byteLength,
+                        });
+                        const upload_url = res.upload_url;
+                        // Upload file to Slack
+                        await gaxios.request({
+                            method: "POST",
+                            url: upload_url,
+                            data: buffer,
+                        });
+                        // Finalize upload and give metadata for channel, title and
+                        // comment for the file to be posted.
+                        await slack.files.completeUploadExternal({
+                            files: [{
+                                    id: res.file_id ? res.file_id : "",
+                                    title: fileName,
+                                }],
+                            channel_id: channel,
+                        }).catch((e) => {
+                            winston.error(`${LOG_PREFIX} ${e.message}`, { webhookId });
+                            reject(e);
+                        });
+                        // Workaround for regression in V2 upload, the initial
+                        // comment does not support markdown formatting, breaking
+                        // customer links
+                        if (comment !== "") {
+                            await slack.chat.postMessage({
+                                channel: request.formParams.channel,
+                                text: comment,
                             }).catch((e) => {
                                 winston.error(`${LOG_PREFIX} ${e.message}`, { webhookId });
                                 reject(e);
                             });
-                            // Workaround for regression in V2 upload, the initial
-                            // comment does not support markdown formatting, breaking
-                            // customer links
-                            if (comment !== "") {
-                                await slack.chat.postMessage({
-                                    channel: request.formParams.channel,
-                                    text: comment,
-                                }).catch((e) => {
-                                    winston.error(`${LOG_PREFIX} ${e.message}`, { webhookId });
-                                    reject(e);
-                                });
-                            }
                         }
                         resolve();
                     });

--- a/src/actions/slack/test_utils.ts
+++ b/src/actions/slack/test_utils.ts
@@ -26,10 +26,6 @@ function expectSlackMatch(request: Hub.ActionRequest, optionsMatch: FilesUploadA
         return {}
     })
 
-    const convertUser = sinon.spy(async (_options: any) => {
-        return {channel: {id: "D98765"}}
-    })
-
     const finalizeSpy = sinon.spy(async (params: any) => {
         chai.expect(params.files[0].id).to.equal(fileId)
         chai.expect(params.files[0].title).to.equal(optionsMatch.filename)
@@ -39,7 +35,6 @@ function expectSlackMatch(request: Hub.ActionRequest, optionsMatch: FilesUploadA
         return {}
     })
 
-    const stubUserUrl = sinon.stub(slackClient.conversations, "open").callsFake(convertUser)
     const stubClientURL = sinon.stub(slackClient.files, "getUploadURLExternal").callsFake(uploadUrlSpy)
     const stubUpload = sinon.stub(gaxios, "request").callsFake(filesUploadSpy)
     const stubFinalize = sinon.stub(slackClient.files, "completeUploadExternal").callsFake(finalizeSpy)
@@ -55,7 +50,6 @@ function expectSlackMatch(request: Hub.ActionRequest, optionsMatch: FilesUploadA
         stubUpload.restore()
         stubFinalize.restore()
         stubSuggestedFilename.restore()
-        stubUserUrl.restore()
     })
 }
 

--- a/src/actions/slack/utils.ts
+++ b/src/actions/slack/utils.ts
@@ -125,7 +125,8 @@ export const getDisplayedFormFields = async (slack: WebClient, channelType: stri
     return response
 }
 const convertUMTokens = async (channel: string, slack: WebClient): Promise<string> => {
-    const openResponse = await slack.conversations.open({channel: channel})
+    winston.info(`Converting token ${channel}`)
+    const openResponse = await slack.conversations.open({users: channel})
     if (openResponse.error) {
         throw openResponse.error
     } else if (!openResponse?.channel?.id) {
@@ -177,9 +178,6 @@ export const handleExecute = async (request: Hub.ActionRequest, slack: WebClient
                             {webhookId},
                         )
 
-                        // Unfortunately UploadV2 does not provide a way to upload files
-                        // to user tokens which are common in Looker schedules
-                        // (UXXXXXXX)
                         winston.info(`${LOG_PREFIX} V2 Upload of file`, {webhookId})
                         const res = await slack.files.getUploadURLExternal({
                             filename: fileName,


### PR DESCRIPTION
~This is currently a breaking change requiring `channel:manage`, `im:write`,`mpim:write`, and `groups:write` added to the scope permissions~

Managed to rewrite in a way that requires no scope creep. If you pass a UXXXX token to `chat.postMessage()` you will receive an implicit conversion to direct message token types (DXXXXX). This was not documented by slack documentation.