### PR TITLE
Add string as possibility for query_id

### DIFF
--- a/lib/hub/action_request.d.ts
+++ b/lib/hub/action_request.d.ts
@@ -27,7 +27,7 @@ export interface ActionScheduledPlan {
     /** URL of the content item in Looker. */
     url?: string | null;
     /** ID of the query that the data payload represents. */
-    queryId?: number | null;
+    queryId?: string | number | null;
     /** Query that was run (not available for dashboards) */
     query?: Query | null;
     /** A boolean representing whether this schedule payload has customized the filter values. */

--- a/src/hub/action_request.ts
+++ b/src/hub/action_request.ts
@@ -53,7 +53,7 @@ export interface ActionScheduledPlan {
   /** URL of the content item in Looker. */
   url?: string | null
   /** ID of the query that the data payload represents. */
-  queryId?: number | null
+  queryId?: string | number | null
   /** Query that was run (not available for dashboards) */
   query?: Query | null
   /** A boolean representing whether this schedule payload has customized the filter values. */


### PR DESCRIPTION
Looker is moving to using strings instead of numbers for query_ids. Ensure we support this,