### PR TITLE
[HubSpot] Migrate to use Private App Access Token

### DIFF
--- a/src/actions/hubspot/hubspot.ts
+++ b/src/actions/hubspot/hubspot.ts
@@ -44,9 +44,9 @@ export class HubspotAction extends Hub.Action {
   iconName = "hubspot/hubspot.png"
   params = [
     {
-      description: "An api key for Hubspot.",
-      label: "Hubspot API Key",
-      name: "hubspot_api_key",
+      description: "Access Token of your Private Hubspot App.",
+      label: "Hubspot Access Token",
+      name: "hubspot_access_token",
       required: true,
       sensitive: true,
     },
@@ -95,7 +95,7 @@ export class HubspotAction extends Hub.Action {
   }
 
   protected hubspotClientFromRequest(request: Hub.ActionRequest) {
-    return new hubspot.Client({ apiKey: request.params.hubspot_api_key })
+    return new hubspot.Client({ accessToken: request.params.hubspot_access_token })
   }
 
   protected taggedFields(fields: Hub.Field[], tags: string[]) {
@@ -245,6 +245,7 @@ export class HubspotAction extends Hub.Action {
     }
 
     if (errors.length > 0) {
+      winston.debug(`Hubspot encountered errors: ${util.inspect(errors)}`)
       let msg = errors.map((e) => (e.message ? e.message : e)).join(", ")
       if (msg.length === 0) {
         msg = "An unknown error occurred while processing the Hubspot action."

--- a/src/actions/hubspot/test_hubspot_companies.ts
+++ b/src/actions/hubspot/test_hubspot_companies.ts
@@ -11,7 +11,7 @@ describe(`${action.constructor.name} unit tests`, () => {
     const request = new Hub.ActionRequest()
     request.type = Hub.ActionType.Query
     request.params = {
-      hubspot_api_key: "hubspot_key",
+      hubspot_access_token: "hubspot_access_token",
     }
     request.attachment = {
       dataBuffer: Buffer.from(
@@ -62,7 +62,7 @@ describe(`${action.constructor.name} unit tests`, () => {
     const request = new Hub.ActionRequest()
     request.type = Hub.ActionType.Query
     request.params = {
-      hubspot_api_key: "hubspot_key",
+      hubspot_access_token: "hubspot_access_token",
     }
     request.attachment = {
       dataBuffer: Buffer.from(

--- a/src/actions/hubspot/test_hubspot_contacts.ts
+++ b/src/actions/hubspot/test_hubspot_contacts.ts
@@ -11,7 +11,7 @@ describe(`${action.constructor.name} unit tests`, () => {
     const request = new Hub.ActionRequest()
     request.type = Hub.ActionType.Query
     request.params = {
-      hubspot_api_key: "hubspot_key",
+      hubspot_access_token: "hubspot_access_token",
     }
     request.attachment = {
       dataBuffer: Buffer.from(
@@ -62,7 +62,7 @@ describe(`${action.constructor.name} unit tests`, () => {
     const request = new Hub.ActionRequest()
     request.type = Hub.ActionType.Query
     request.params = {
-      hubspot_api_key: "hubspot_key",
+      hubspot_access_token: "hubspot_access_token",
     }
     request.attachment = {
       dataBuffer: Buffer.from(
@@ -99,7 +99,7 @@ describe(`${action.constructor.name} unit tests`, () => {
     const request = new Hub.ActionRequest()
     request.type = Hub.ActionType.Query
     request.params = {
-      hubspot_api_key: "hubspot_key",
+      hubspot_access_token: "hubspot_access_token",
     }
     request.attachment = {
       dataBuffer: Buffer.from(


### PR DESCRIPTION
As per https://developers.hubspot.com/docs/guides/apps/private-apps/migrate-an-api-key-integration-to-a-private-app, HubSpot expects to work with Private App Access Token's now.

The change in this PR makes the HubSpot actions work with said Private App Access Token instead.

Otherwise Hubspot actions are unchanged.