### PR TITLE
Enforce Max delivery size on Slack (Slack's own limit)

### DIFF
--- a/lib/actions/hubspot/hubspot.js
+++ b/lib/actions/hubspot/hubspot.js
@@ -30,9 +30,9 @@ class HubspotAction extends Hub.Action {
         this.iconName = "hubspot/hubspot.png";
         this.params = [
             {
-                description: "An api key for Hubspot.",
-                label: "Hubspot API Key",
-                name: "hubspot_api_key",
+                description: "Access Token of your Private Hubspot App.",
+                label: "Hubspot Access Token",
+                name: "hubspot_access_token",
                 required: true,
                 sensitive: true,
             },
@@ -70,7 +70,7 @@ class HubspotAction extends Hub.Action {
         return this.executeHubspot(request);
     }
     hubspotClientFromRequest(request) {
-        return new hubspot.Client({ apiKey: request.params.hubspot_api_key });
+        return new hubspot.Client({ accessToken: request.params.hubspot_access_token });
     }
     taggedFields(fields, tags) {
         return fields.filter((f) => f.tags &&
@@ -198,6 +198,7 @@ class HubspotAction extends Hub.Action {
             errors.push(e);
         }
         if (errors.length > 0) {
+            winston.debug(`Hubspot encountered errors: ${util.inspect(errors)}`);
             let msg = errors.map((e) => (e.message ? e.message : e)).join(", ");
             if (msg.length === 0) {
                 msg = "An unknown error occurred while processing the Hubspot action.";

--- a/lib/actions/slack/utils.d.ts
+++ b/lib/actions/slack/utils.d.ts
@@ -2,6 +2,7 @@ import { WebClient } from "@slack/web-api";
 import * as Hub from "../../hub";
 import { ActionFormField } from "../../hub";
 export declare const API_LIMIT_SIZE = 1000;
+export declare const MAX_SIZE: number;
 export declare const getDisplayedFormFields: (slack: WebClient, channelType: string) => Promise<ActionFormField[]>;
 export declare const handleExecute: (request: Hub.ActionRequest, slack: WebClient) => Promise<Hub.ActionResponse>;
 export declare const displayError: {

--- a/lib/actions/slack/utils.js
+++ b/lib/actions/slack/utils.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.displayError = exports.handleExecute = exports.getDisplayedFormFields = exports.API_LIMIT_SIZE = void 0;
+exports.displayError = exports.handleExecute = exports.getDisplayedFormFields = exports.MAX_SIZE = exports.API_LIMIT_SIZE = void 0;
 const web_api_1 = require("@slack/web-api");
 const gaxios = require("gaxios");
 const winston = require("winston");
@@ -8,6 +8,7 @@ const http_errors_1 = require("../../error_types/http_errors");
 const Hub = require("../../hub");
 const action_response_1 = require("../../hub/action_response");
 exports.API_LIMIT_SIZE = 1000;
+exports.MAX_SIZE = 2 ** 30;
 const LOG_PREFIX = "[SLACK]";
 const _usableChannels = async (slack) => {
     const options = {
@@ -139,7 +140,12 @@ const handleExecute = async (request, slack) => {
                 await new Promise((resolve, reject) => {
                     readable.on("readable", () => {
                         let buff = readable.read();
+                        let size = 0;
                         while (buff) {
+                            size += buff.length;
+                            if (size > exports.MAX_SIZE) {
+                                reject("Payload was over 1 GB which is not supported");
+                            }
                             buffs.push(buff);
                             buff = readable.read();
                         }

--- a/src/actions/slack/utils.ts
+++ b/src/actions/slack/utils.ts
@@ -7,6 +7,7 @@ import {ActionFormField} from "../../hub"
 import { Error, errorWith } from "../../hub/action_response"
 
 export const API_LIMIT_SIZE = 1000
+export const MAX_SIZE = 2 ** 30
 
 const LOG_PREFIX = "[SLACK]"
 
@@ -153,7 +154,12 @@ export const handleExecute = async (request: Hub.ActionRequest, slack: WebClient
                 await new Promise<void>((resolve, reject) => {
                     readable.on("readable", () => {
                         let buff = readable.read()
+                        let size = 0
                         while (buff) {
+                            size += buff.length
+                            if (size > MAX_SIZE) {
+                                reject("Payload was over 1 GB which is not supported")
+                            }
                             buffs.push(buff)
                             buff = readable.read()
                         }


### PR DESCRIPTION
Slack has a 1 GB limit for files which would fail anyways, and the buffer would occasionally overflow memory. Send back an informative error instead.

hubspot.js file was just missed in a previous merge, it is code that should have already been included