### PR TITLE
Cork streams before getting a response

### DIFF
--- a/lib/hub/action_request.js
+++ b/lib/hub/action_request.js
@@ -121,6 +121,9 @@ class ActionRequest {
             if (url) {
                 winston.info(`[stream] beginning stream via download url`, this.logInfo);
                 let hasResolved = false;
+                // Here we can cork the stream and uncork if we receive a 200 OK response
+                // If we do not receive a 200 we do not want to allow data to pipe and ignore a non-200 response
+                stream.cork();
                 httpRequest
                     .get(url, { timeout })
                     .on("error", (err) => {
@@ -137,7 +140,11 @@ class ActionRequest {
                     }
                 })
                     .on("response", (response) => {
-                    if (response.statusCode !== 200) {
+                    if (response.statusCode === 200) {
+                        // Stop buffering in memory and allow action to send data
+                        stream.uncork();
+                    }
+                    else {
                         winston.warn(`[stream] There was an error received from Looker.` +
                             `ErrorCode: ${response.statusCode} ErrorMessage: ${response.statusMessage}`, this.logInfo);
                         if (!hasResolved) {

--- a/src/hub/action_request.ts
+++ b/src/hub/action_request.ts
@@ -191,6 +191,9 @@ export class ActionRequest {
       if (url) {
         winston.info(`[stream] beginning stream via download url`, this.logInfo)
         let hasResolved = false
+        // Here we can cork the stream and uncork if we receive a 200 OK response
+        // If we do not receive a 200 we do not want to allow data to pipe and ignore a non-200 response
+        stream.cork()
         httpRequest
           .get(url, {timeout})
           .on("error", (err) => {
@@ -206,7 +209,10 @@ export class ActionRequest {
             }
           })
           .on("response", (response) => {
-            if (response.statusCode !== 200) {
+            if (response.statusCode === 200) {
+              // Stop buffering in memory and allow action to send data
+              stream.uncork()
+            } else {
               winston.warn(`[stream] There was an error received from Looker.` +
                   `ErrorCode: ${response.statusCode} ErrorMessage: ${response.statusMessage}`, this.logInfo)
               if (!hasResolved) {


### PR DESCRIPTION
This will prevent sending data through the streams before knowing if the response was actually going to give data