### PR TITLE
Adds checks to ensure error message gets correctly extracted.

### DIFF
--- a/lib/xpc/execute_process.js
+++ b/lib/xpc/execute_process.js
@@ -17,8 +17,22 @@ process.on("message", (req) => {
     execute(req)
         .then((val) => { process.send(val); })
         .catch((err) => {
-        const stringErr = JSON.stringify(err);
-        winston.error("Error on child: " + stringErr);
-        process.send({ success: false, message: stringErr });
+        let errorString;
+        if (err instanceof Error) {
+            errorString = err.message || err.toString();
+        }
+        else if (typeof err === 'object' && err !== null) {
+            try {
+                errorString = JSON.stringify(err);
+            }
+            catch (jsonError) {
+                errorString = `[Object could not be stringified: ${jsonError.message || jsonError.toString()}]`;
+            }
+        }
+        else {
+            errorString = String(err);
+        }
+        winston.error("Error on child: " + errorString);
+        process.send({ success: false, message: errorString });
     });
 });

--- a/lib/xpc/execute_process.js
+++ b/lib/xpc/execute_process.js
@@ -21,7 +21,7 @@ process.on("message", (req) => {
         if (err instanceof Error) {
             errorString = err.message || err.toString();
         }
-        else if (typeof err === 'object' && err !== null) {
+        else if (typeof err === "object" && err !== null) {
             try {
                 errorString = JSON.stringify(err);
             }

--- a/lib/xpc/execute_process.js
+++ b/lib/xpc/execute_process.js
@@ -32,7 +32,8 @@ process.on("message", (req) => {
         else {
             errorString = String(err);
         }
-        winston.error("Error on child: " + errorString);
+        const request = Hub.ActionRequest.fromIPC(req);
+        winston.error(`Error on child: ${errorString}. WebhookID: ${request.webhookId}`);
         process.send({ success: false, message: errorString });
     });
 });

--- a/lib/xpc/extended_execute_process.js
+++ b/lib/xpc/extended_execute_process.js
@@ -20,8 +20,22 @@ process.on("message", (req) => {
     execute(req)
         .then((val) => { process.send(val); })
         .catch((err) => {
-        const stringErr = JSON.stringify(err);
-        winston.error("Error on child: " + stringErr);
-        process.send({ success: false, message: stringErr });
+        let errorString;
+        if (err instanceof Error) {
+            errorString = err.message || err.toString();
+        }
+        else if (typeof err === 'object' && err !== null) {
+            try {
+                errorString = JSON.stringify(err);
+            }
+            catch (jsonError) {
+                errorString = `[Object could not be stringified: ${jsonError.message || jsonError.toString()}]`;
+            }
+        }
+        else {
+            errorString = String(err);
+        }
+        winston.error("Error on child: " + errorString);
+        process.send({ success: false, message: errorString });
     });
 });

--- a/lib/xpc/extended_execute_process.js
+++ b/lib/xpc/extended_execute_process.js
@@ -24,7 +24,7 @@ process.on("message", (req) => {
         if (err instanceof Error) {
             errorString = err.message || err.toString();
         }
-        else if (typeof err === 'object' && err !== null) {
+        else if (typeof err === "object" && err !== null) {
             try {
                 errorString = JSON.stringify(err);
             }

--- a/lib/xpc/extended_execute_process.js
+++ b/lib/xpc/extended_execute_process.js
@@ -35,7 +35,8 @@ process.on("message", (req) => {
         else {
             errorString = String(err);
         }
-        winston.error("Error on child: " + errorString);
+        const request = Hub.ActionRequest.fromIPC(req);
+        winston.error(`Error on child: ${errorString}. WebhookID: ${request.webhookId}`);
         process.send({ success: false, message: errorString });
     });
 });

--- a/src/xpc/execute_process.ts
+++ b/src/xpc/execute_process.ts
@@ -31,7 +31,8 @@ process.on("message", (req) => {
             } else {
                 errorString = String(err)
             }
-            winston.error("Error on child: " + errorString)
+            const request = Hub.ActionRequest.fromIPC(req)
+            winston.error(`Error on child: ${errorString}. WebhookID: ${request.webhookId}`)
             process.send!({success: false, message: errorString})
         })
 })

--- a/src/xpc/execute_process.ts
+++ b/src/xpc/execute_process.ts
@@ -19,8 +19,19 @@ process.on("message", (req) => {
     execute(req)
         .then((val) => { process.send!(val)})
         .catch((err) => {
-            const stringErr = JSON.stringify(err)
-            winston.error("Error on child: " + stringErr)
-            process.send!({success: false, message: stringErr})
+            let errorString;
+            if (err instanceof Error) {
+                errorString = err.message || err.toString();
+            } else if (typeof err === 'object' && err !== null) {
+                try {
+                    errorString = JSON.stringify(err);
+                } catch (jsonError: any) {
+                    errorString = `[Object could not be stringified: ${jsonError.message || jsonError.toString()}]`;
+                }
+            } else {
+                errorString = String(err);
+            }
+            winston.error("Error on child: " + errorString);
+            process.send!({success: false, message: errorString});
         })
 })

--- a/src/xpc/execute_process.ts
+++ b/src/xpc/execute_process.ts
@@ -19,19 +19,19 @@ process.on("message", (req) => {
     execute(req)
         .then((val) => { process.send!(val)})
         .catch((err) => {
-            let errorString;
+            let errorString
             if (err instanceof Error) {
-                errorString = err.message || err.toString();
+                errorString = err.message || err.toString()
             } else if (typeof err === 'object' && err !== null) {
                 try {
-                    errorString = JSON.stringify(err);
+                    errorString = JSON.stringify(err)
                 } catch (jsonError: any) {
-                    errorString = `[Object could not be stringified: ${jsonError.message || jsonError.toString()}]`;
+                    errorString = `[Object could not be stringified: ${jsonError.message || jsonError.toString()}]`
                 }
             } else {
-                errorString = String(err);
+                errorString = String(err)
             }
-            winston.error("Error on child: " + errorString);
-            process.send!({success: false, message: errorString});
+            winston.error("Error on child: " + errorString)
+            process.send!({success: false, message: errorString})
         })
 })

--- a/src/xpc/execute_process.ts
+++ b/src/xpc/execute_process.ts
@@ -22,7 +22,7 @@ process.on("message", (req) => {
             let errorString
             if (err instanceof Error) {
                 errorString = err.message || err.toString()
-            } else if (typeof err === 'object' && err !== null) {
+            } else if (typeof err === "object" && err !== null) {
                 try {
                     errorString = JSON.stringify(err)
                 } catch (jsonError: any) {

--- a/src/xpc/extended_execute_process.ts
+++ b/src/xpc/extended_execute_process.ts
@@ -34,7 +34,8 @@ process.on("message", (req) => {
       } else {
           errorString = String(err)
       }
-      winston.error("Error on child: " + errorString)
+      const request = Hub.ActionRequest.fromIPC(req)
+      winston.error(`Error on child: ${errorString}. WebhookID: ${request.webhookId}`)
       process.send!({success: false, message: errorString})
     })
 })

--- a/src/xpc/extended_execute_process.ts
+++ b/src/xpc/extended_execute_process.ts
@@ -22,19 +22,19 @@ process.on("message", (req) => {
   execute(req)
     .then((val) => { process.send!(val) })
     .catch((err) => {
-      let errorString;
+      let errorString
       if (err instanceof Error) {
-          errorString = err.message || err.toString();
+          errorString = err.message || err.toString()
       } else if (typeof err === 'object' && err !== null) {
           try {
-              errorString = JSON.stringify(err);
+              errorString = JSON.stringify(err)
           } catch (jsonError: any) {
-              errorString = `[Object could not be stringified: ${jsonError.message || jsonError.toString()}]`;
+              errorString = `[Object could not be stringified: ${jsonError.message || jsonError.toString()}]`
           }
       } else {
-          errorString = String(err);
+          errorString = String(err)
       }
-      winston.error("Error on child: " + errorString);
-      process.send!({success: false, message: errorString});
+      winston.error("Error on child: " + errorString)
+      process.send!({success: false, message: errorString})
     })
 })

--- a/src/xpc/extended_execute_process.ts
+++ b/src/xpc/extended_execute_process.ts
@@ -25,7 +25,7 @@ process.on("message", (req) => {
       let errorString
       if (err instanceof Error) {
           errorString = err.message || err.toString()
-      } else if (typeof err === 'object' && err !== null) {
+      } else if (typeof err === "object" && err !== null) {
           try {
               errorString = JSON.stringify(err)
           } catch (jsonError: any) {

--- a/src/xpc/extended_execute_process.ts
+++ b/src/xpc/extended_execute_process.ts
@@ -22,8 +22,19 @@ process.on("message", (req) => {
   execute(req)
     .then((val) => { process.send!(val) })
     .catch((err) => {
-      const stringErr = JSON.stringify(err)
-      winston.error("Error on child: " + stringErr)
-      process.send!({success: false, message: stringErr})
+      let errorString;
+      if (err instanceof Error) {
+          errorString = err.message || err.toString();
+      } else if (typeof err === 'object' && err !== null) {
+          try {
+              errorString = JSON.stringify(err);
+          } catch (jsonError: any) {
+              errorString = `[Object could not be stringified: ${jsonError.message || jsonError.toString()}]`;
+          }
+      } else {
+          errorString = String(err);
+      }
+      winston.error("Error on child: " + errorString);
+      process.send!({success: false, message: errorString});
     })
 })


### PR DESCRIPTION
There have been customer issues where they are receiving an error 'error on child: {}'. This usually indicates that the error has non-enumerable properties. This change adds a check to see if the error is of type Error. It also adds increased logging to tell us if the error cannot be Stringified.