### PR TITLE
narrow the return type of oauthFetchAccessToken

### DIFF
--- a/lib/hub/oauth_action_v2.d.ts
+++ b/lib/hub/oauth_action_v2.d.ts
@@ -6,7 +6,10 @@ export declare abstract class OAuthActionV2 extends Action {
     abstract oauthHandleRedirect(urlParams: {
         [key: string]: string;
     }, redirectUri: string): Promise<string>;
-    abstract oauthFetchAccessToken(request: ActionRequest): Promise<object>;
+    abstract oauthFetchAccessToken(request: ActionRequest): Promise<{
+        tokens: any;
+        redirect: any;
+    }>;
     asJson(router: RouteBuilder, request: ActionRequest): any;
 }
 export declare function isOauthActionV2(action: Action): boolean;

--- a/src/hub/oauth_action_v2.ts
+++ b/src/hub/oauth_action_v2.ts
@@ -5,7 +5,7 @@ export abstract class OAuthActionV2 extends Action {
   abstract oauthCheck(request: ActionRequest): Promise<boolean>
   abstract oauthUrl(redirectUri: string, encryptedState: string): Promise<string>
   abstract oauthHandleRedirect(urlParams: { [key: string]: string }, redirectUri: string): Promise<string>
-  abstract oauthFetchAccessToken(request: ActionRequest): Promise<object>
+  abstract oauthFetchAccessToken(request: ActionRequest): Promise<{ tokens: any; redirect: any; }>
 
   asJson(router: RouteBuilder, request: ActionRequest): any {
     const json = super.asJson(router, request)


### PR DESCRIPTION
We should return a narrower type than "object" for `OAuthActionV2.oauthFetchAccessToken`