### PR TITLE
Map state_url from root and fix gaxios payload formatting 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ typings/
 
 # ActionHub specifics
 status.json
+
+# Internal Tooling
+.agent/
+.gemini/
+tasks/

--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,3 @@ typings/
 
 # ActionHub specifics
 status.json
-
-# Internal Tooling
-.agent/
-.gemini/
-tasks/

--- a/lib/hub/action_request.js
+++ b/lib/hub/action_request.js
@@ -82,6 +82,18 @@ class ActionRequest {
         if (json.data) {
             request.params = json.data;
         }
+        if (json.state_url) {
+            if (request.params === undefined) {
+                request.params = {};
+            }
+            request.params.state_url = json.state_url;
+        }
+        if (json.state_redir_url) {
+            if (request.params === undefined) {
+                request.params = {};
+            }
+            request.params.state_redir_url = json.state_redir_url;
+        }
         if (json.form_params) {
             request.formParams = json.form_params;
         }

--- a/lib/hub/action_request.js
+++ b/lib/hub/action_request.js
@@ -82,17 +82,12 @@ class ActionRequest {
         if (json.data) {
             request.params = json.data;
         }
-        if (json.state_url) {
-            if (request.params === undefined) {
-                request.params = {};
-            }
-            request.params.state_url = json.state_url;
+        const jsonAny = json;
+        if (jsonAny.state_url) {
+            request.params.state_url = jsonAny.state_url;
         }
-        if (json.state_redir_url) {
-            if (request.params === undefined) {
-                request.params = {};
-            }
-            request.params.state_redir_url = json.state_redir_url;
+        if (jsonAny.state_redir_url) {
+            request.params.state_redir_url = jsonAny.state_redir_url;
         }
         if (json.form_params) {
             request.formParams = json.form_params;

--- a/lib/hub/oauth_action.d.ts
+++ b/lib/hub/oauth_action.d.ts
@@ -20,9 +20,9 @@ export declare abstract class OAuthAction extends Action {
     /**
      * Conditionally encrypts token payloads based on the per-action environment config.
      * - If `ENCRYPT_PAYLOAD_<ACTION_NAME>` is "true", returns an EncryptedPayload.
-     * - Otherwise, returns a standard stringified JSON payload.
+     * - Otherwise, returns the raw JSON object so standard libraries like gaxios can set the correct Content-Type header.
      */
-    oauthMaybeEncryptTokens(tokenPayload: any, requestWebhookId: string | undefined): Promise<EncryptedPayload | string>;
+    oauthMaybeEncryptTokens(tokenPayload: any, requestWebhookId: string | undefined): Promise<EncryptedPayload | any>;
     oauthDecryptTokens(encryptedPayload: EncryptedPayload, requestWebhookId: string | undefined): Promise<Record<string, any>>;
 }
 export declare function isOauthAction(action: Action): boolean;

--- a/lib/hub/oauth_action.js
+++ b/lib/hub/oauth_action.js
@@ -54,13 +54,13 @@ class OAuthAction extends action_1.Action {
     /**
      * Conditionally encrypts token payloads based on the per-action environment config.
      * - If `ENCRYPT_PAYLOAD_<ACTION_NAME>` is "true", returns an EncryptedPayload.
-     * - Otherwise, returns a standard stringified JSON payload.
+     * - Otherwise, returns the raw JSON object so standard libraries like gaxios can set the correct Content-Type header.
      */
     async oauthMaybeEncryptTokens(tokenPayload, requestWebhookId) {
         const envVarName = `ENCRYPT_PAYLOAD_${this.name.toUpperCase()}`;
         const perActionEncryptionValue = process.env[envVarName];
         if (perActionEncryptionValue !== "true") {
-            return JSON.stringify(tokenPayload);
+            return tokenPayload;
         }
         const encrypted = await OAuthAction.actionCrypto.encrypt(JSON.stringify(tokenPayload)).catch((err) => {
             winston.error("Encryption not correctly configured", { webhookId: requestWebhookId, action: this.name });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "looker-action-hub",
-  "version": "1.5.31",
+  "version": "1.5.33",
   "description": "",
   "main": "lib/index",
   "scripts": {

--- a/src/actions/airtable/test_airtable.ts
+++ b/src/actions/airtable/test_airtable.ts
@@ -459,6 +459,40 @@ describe(`${action.constructor.name} unit tests`, () => {
         chai.expect(secondCallArgs.data).to.not.be.undefined // We want data to be used
         chai.expect(secondCallArgs.body).to.be.undefined // We want body to be unused
       })
+
+      it("sends an object payload instead of a string to ensure gaxios sets the correct Content-Type", async () => {
+        const urlParams = {
+          code: "test_code",
+          state: b64.encode(JSON.stringify({
+            verifier: "test_verifier",
+            stateurl: "test_state_url",
+          })),
+        }
+        const redirectUri = "http://redirect"
+
+        gaxiosStub.onFirstCall().resolves({
+          status: 200,
+          data: {
+            access_token: "fresh_access",
+            refresh_token: "fresh_refresh",
+          },
+        })
+
+        gaxiosStub.onSecondCall().resolves({
+          status: 200,
+          data: {},
+        })
+
+        // Ensure encryption is OFF to test the unencrypted fallback
+        delete process.env.ENCRYPT_PAYLOAD_AIRTABLE
+        await action.oauthFetchInfo(urlParams, redirectUri)
+
+        const secondCallArgs = gaxiosStub.secondCall.args[0]
+        // This is the crucial assertion: If data is a string, gaxios will set Content-Type to text/plain.
+        // It MUST be an object for gaxios to set Content-Type to application/json.
+        chai.expect(typeof secondCallArgs.data).to.equal("object")
+        chai.expect(typeof secondCallArgs.data).to.not.equal("string")
+      })
     })
   })
 })

--- a/src/actions/dropbox/dropbox.ts
+++ b/src/actions/dropbox/dropbox.ts
@@ -171,6 +171,7 @@ export class DropboxAction extends Hub.OAuthAction {
     await https.post({
       url: payload.stateurl,
       body: encrypted,
+      json: true,
     }).catch((_err) => { winston.error(_err.toString()) })
   }
 

--- a/src/actions/dropbox/test_dropbox.ts
+++ b/src/actions/dropbox/test_dropbox.ts
@@ -251,7 +251,7 @@ describe(`${action.constructor.name} unit tests`, () => {
         `c2RmIiwiYXBwIjoibXlrZXkifQ`}, "redirect")
 
       chai.expect(stubEncrypt).to.have.been.calledWithMatch({code: "code", redirect: "redirect"})
-      chai.expect(stubPost).to.have.been.calledWithMatch({body: "encrypted_state"})
+      chai.expect(stubPost).to.have.been.calledWithMatch({body: "encrypted_state", json: true})
 
       stubEncrypt.restore()
       stubPost.restore()

--- a/src/actions/facebook/test_facebook_custom_audiences.ts
+++ b/src/actions/facebook/test_facebook_custom_audiences.ts
@@ -169,7 +169,7 @@ describe(`${action.constructor.name} class`, () => {
         const expectedPostArgs = {
           method: "POST",
           url: stateUrl,
-          data: JSON.stringify({ tokens: stubTokens, redirect: redirectUri }),
+          data: { tokens: stubTokens, redirect: redirectUri },
         }
 
         await action.oauthFetchInfo({code: oauthCode, state: encryptedPayload}, redirectUri)

--- a/src/actions/google/ads/test_customer_match.ts
+++ b/src/actions/google/ads/test_customer_match.ts
@@ -195,17 +195,17 @@ describe(`${action.constructor.name} class`, () => {
 
         await action.oauthFetchInfo({code: oauthCode, state: encryptedPayload}, redirectUri)
 
-        expect(oauthClientStub).to.be.calledOnce
+        expect(oauthClientStub.calledOnce).to.be.true
         expect(oauthClientStub.getCall(0).args).to.deep.equal([
           "test_oauth_client_id",
           "test_oauth_client_secret",
           redirectUri,
         ])
 
-        expect(getTokenStub).to.be.calledOnce
+        expect(getTokenStub.calledOnce).to.be.true
         expect(getTokenStub.getCall(0).args[0]).to.equal(oauthCode)
 
-        expect(gaxiosStub).to.be.calledOnce
+        expect(gaxiosStub.calledOnce).to.be.true
         expect(gaxiosStub.getCall(0).args[0]).to.deep.equal(expectedPostArgs)
       })
 
@@ -247,8 +247,7 @@ describe(`${action.constructor.name} class`, () => {
         const decrypted = b64.decode(encrypted)
         const payload = JSON.parse(decrypted)
 
-        // Under the broken code, payload.stateUrl is completely undefined because it looks at request.params!
-        expect(payload.stateUrl).to.be.undefined
+        expect(payload.stateUrl).to.equal("https://looker.example.com/state_url_endpoint")
       })
     })
   })

--- a/src/actions/google/ads/test_customer_match.ts
+++ b/src/actions/google/ads/test_customer_match.ts
@@ -190,7 +190,7 @@ describe(`${action.constructor.name} class`, () => {
         const expectedPostArgs = {
           method: "POST",
           url: stateUrl,
-          data: JSON.stringify({ tokens: stubTokens, redirect: redirectUri }),
+          data: { tokens: stubTokens, redirect: redirectUri },
         }
 
         await action.oauthFetchInfo({code: oauthCode, state: encryptedPayload}, redirectUri)
@@ -218,6 +218,37 @@ describe(`${action.constructor.name} class`, () => {
         request.params = {}
         const result = await action.oauthCheck(request)
         expect(result).to.be.false
+      })
+    })
+    describe("state_url parsing bug reproduction", () => {
+      it("fails to pass stateUrl into payload if state_url is mapped to the root of JSON request", async () => {
+        // Looker Action API states state_url is generated per form request and sent inside the body root
+        const jsonPayload = {
+          type: "form",
+          webhookId: "test_webhook_id",
+          state_url: "https://looker.example.com/state_url_endpoint",
+          data: {
+             clientCid: testClientCid,
+          },
+        } as any
+
+        // This simulates action_request.ts mapping the JSON data
+        const request = Hub.ActionRequest.fromJSON(jsonPayload)
+
+        // This simulates the OAuthHelper generating the login form payload
+        const form = await action.oauthHelper.makeLoginForm(request)
+        const authUrl = (form.fields[0] as any).oauth_url
+
+        // The URL looks like BASE_URL/actions/action_name/oauth?state=ENCRYPTED_PAYLOAD
+        const urlParams = new URLSearchParams(authUrl.split("?")[1])
+        const encrypted = urlParams.get("state")!
+
+        // Inside actionCrypto, our test mock encodes as base64 instead of actual encrypt
+        const decrypted = b64.decode(encrypted)
+        const payload = JSON.parse(decrypted)
+
+        // Under the broken code, payload.stateUrl is completely undefined because it looks at request.params!
+        expect(payload.stateUrl).to.be.undefined
       })
     })
   })

--- a/src/actions/google/analytics/test_data_import.ts
+++ b/src/actions/google/analytics/test_data_import.ts
@@ -727,7 +727,7 @@ describe(`${action.constructor.name} class`, () => {
         const expectedPostArgs = {
           method: "POST",
           url: stateUrl,
-          data: JSON.stringify({tokens: stubTokens, redirect: redirectUri}),
+          data: {tokens: stubTokens, redirect: redirectUri},
         }
 
         await action.oauthFetchInfo({code: oauthCode, state: encryptedPayload}, redirectUri)

--- a/src/hub/action_request.ts
+++ b/src/hub/action_request.ts
@@ -136,6 +136,20 @@ export class ActionRequest {
       request.params = json.data
     }
 
+    if ((json as any).state_url) {
+      if (request.params === undefined) {
+        request.params = {}
+      }
+      request.params.state_url = (json as any).state_url
+    }
+
+    if ((json as any).state_redir_url) {
+      if (request.params === undefined) {
+        request.params = {}
+      }
+      request.params.state_redir_url = (json as any).state_redir_url
+    }
+
     if (json.form_params) {
       request.formParams = json.form_params
     }

--- a/src/hub/action_request.ts
+++ b/src/hub/action_request.ts
@@ -136,18 +136,13 @@ export class ActionRequest {
       request.params = json.data
     }
 
-    if ((json as any).state_url) {
-      if (request.params === undefined) {
-        request.params = {}
-      }
-      request.params.state_url = (json as any).state_url
+    const jsonAny = json as any
+    if (jsonAny.state_url) {
+      request.params.state_url = jsonAny.state_url
     }
 
-    if ((json as any).state_redir_url) {
-      if (request.params === undefined) {
-        request.params = {}
-      }
-      request.params.state_redir_url = (json as any).state_redir_url
+    if (jsonAny.state_redir_url) {
+      request.params.state_redir_url = jsonAny.state_redir_url
     }
 
     if (json.form_params) {

--- a/src/hub/oauth_action.ts
+++ b/src/hub/oauth_action.ts
@@ -69,17 +69,17 @@ export abstract class OAuthAction extends Action {
   /**
    * Conditionally encrypts token payloads based on the per-action environment config.
    * - If `ENCRYPT_PAYLOAD_<ACTION_NAME>` is "true", returns an EncryptedPayload.
-   * - Otherwise, returns a standard stringified JSON payload.
+   * - Otherwise, returns the raw JSON object so standard libraries like gaxios can set the correct Content-Type header.
    */
   async oauthMaybeEncryptTokens(
     tokenPayload: any,
     requestWebhookId: string | undefined,
-  ): Promise<EncryptedPayload | string> {
+  ): Promise<EncryptedPayload | any> {
     const envVarName = `ENCRYPT_PAYLOAD_${this.name.toUpperCase()}`
     const perActionEncryptionValue = process.env[envVarName]
 
     if (perActionEncryptionValue !== "true") {
-      return JSON.stringify(tokenPayload)
+      return tokenPayload
     }
 
     const encrypted = await OAuthAction.actionCrypto.encrypt(JSON.stringify(tokenPayload)).catch((err: string) => {

--- a/test/test_oauth_action.ts
+++ b/test/test_oauth_action.ts
@@ -59,7 +59,7 @@ describe("OAuthAction Encryption", () => {
       process.env.ENCRYPT_PAYLOAD = "true"
       const payload = { tokens: "secret" }
       const result = await action.oauthMaybeEncryptTokens(payload, "webhookId")
-      chai.expect(result).to.equal(JSON.stringify(payload))
+      chai.expect(result).to.deep.equal(payload)
       sinon.assert.notCalled(encryptStub)
     })
 


### PR DESCRIPTION
Mapped  state_url  and  state_redir_url  from the root of the JSON request to  actionRequest.params  in  ActionRequest.fromJSON . This  ensures compatibility with the Looker Action API, which sends these parameters at the root for  form  requests, preventing them from being stripped.                                                                                                                                 
  
- Updated  oauthMaybeEncryptTokens  to return the raw JSON object instead of a stringified representation when payload encryption is disabled. This allows  gaxios  to correctly infer the  application/json  Content-Type header instead of defaulting to  text/plain , which was causing authorization failures with APIs expecting strict JSON (like Google Ads).                                                     
 
 - Added a reproduction unit test in  test_customer_match.ts  to verify the  state_url  parsing behavior.