### PR TITLE
feat(gcs): filename date/time tokens + manual bucket override for cross-project delivery

### DIFF
--- a/src/actions/google/gcs/README.md
+++ b/src/actions/google/gcs/README.md
@@ -22,21 +22,33 @@ The action requires a Google Cloud Storage account, a programmatic service accou
 
 ## Filename date tokens
 
-The **Filename** field supports UTC date tokens, which are substituted at delivery time:
+The **Filename** field supports UTC date/time tokens, which are substituted at delivery time. Each
+token is replaced independently wherever it appears, so you can compose any format using your own
+separators (`-`, `_`, `/`, etc.). Tokens are evaluated for the example moment `2026-06-17 08:30:45`
+UTC below:
 
-| Token        | Meaning                          | Example (2026-06-17 UTC) |
-| ------------ | -------------------------------- | ------------------------ |
-| `{YYYYMMDD}` | 4-digit year + 2-digit month/day | `20260617`               |
-| `{YYYY}`     | 4-digit year                     | `2026`                   |
-| `{MM}`       | 2-digit month (zero-padded)      | `06`                     |
-| `{DD}`       | 2-digit day (zero-padded)        | `17`                     |
+| Token        | Meaning                            | Example    |
+| ------------ | ---------------------------------- | ---------- |
+| `{YYYYMMDD}` | 4-digit year + 2-digit month/day   | `20260617` |
+| `{YYYY}`     | 4-digit year                       | `2026`     |
+| `{YY}`       | 2-digit year                       | `26`       |
+| `{MM}`       | 2-digit month (zero-padded)        | `06`       |
+| `{DD}`       | 2-digit day of month (zero-padded) | `17`       |
+| `{HH}`       | 2-digit hour, 24-hour (zero-padded)| `08`       |
+| `{mm}`       | 2-digit minutes (zero-padded)      | `30`       |
+| `{ss}`       | 2-digit seconds (zero-padded)      | `45`       |
+
+> **Note:** tokens are **case-sensitive**. `{MM}` is the **month** and `{mm}` is **minutes**
+> (the moment.js convention). `{YYYYMMDD}` is simply a convenience for `{YYYY}{MM}{DD}`.
 
 GCS object names may contain `/`, so tokens can be used to date-partition deliveries into "folders":
 
 ```
-report_{YYYYMMDD}.csv          ->  report_20260617.csv
-daily/report_{YYYYMMDD}.csv    ->  gs://<bucket>/daily/report_20260617.csv
-daily/{YYYY}/{MM}/report.csv   ->  gs://<bucket>/daily/2026/06/report.csv
+report_{YYYYMMDD}.csv                 ->  report_20260617.csv
+{YYYY}-{MM}-{DD}.csv                  ->  2026-06-17.csv
+daily/report_{YYYYMMDD}.csv           ->  gs://<bucket>/daily/report_20260617.csv
+daily/{YYYY}/{MM}/report.csv          ->  gs://<bucket>/daily/2026/06/report.csv
+hourly/{YYYYMMDD}T{HH}{mm}{ss}.csv    ->  gs://<bucket>/hourly/20260617T083045.csv
 ```
 
 Filenames with no tokens are written unchanged. When **Overwrite** is set to "No", a uniqueness

--- a/src/actions/google/gcs/README.md
+++ b/src/actions/google/gcs/README.md
@@ -19,3 +19,41 @@ The action requires a Google Cloud Storage account, a programmatic service accou
 ![](Create&#32;GCS&#32;Service&#32;Account.png)
 
 4. Enable Google Cloud Storage in your looker Administration page for actions (/admin/actions).
+
+## Filename date tokens
+
+The **Filename** field supports UTC date tokens, which are substituted at delivery time:
+
+| Token        | Meaning                          | Example (2026-06-17 UTC) |
+| ------------ | -------------------------------- | ------------------------ |
+| `{YYYYMMDD}` | 4-digit year + 2-digit month/day | `20260617`               |
+| `{YYYY}`     | 4-digit year                     | `2026`                   |
+| `{MM}`       | 2-digit month (zero-padded)      | `06`                     |
+| `{DD}`       | 2-digit day (zero-padded)        | `17`                     |
+
+GCS object names may contain `/`, so tokens can be used to date-partition deliveries into "folders":
+
+```
+report_{YYYYMMDD}.csv          ->  report_20260617.csv
+daily/report_{YYYYMMDD}.csv    ->  gs://<bucket>/daily/report_20260617.csv
+daily/{YYYY}/{MM}/report.csv   ->  gs://<bucket>/daily/2026/06/report.csv
+```
+
+Filenames with no tokens are written unchanged. When **Overwrite** is set to "No", a uniqueness
+timestamp is still appended after token substitution.
+
+**Note on time zone:** tokens are resolved using the action hub server's UTC clock, not the timezone
+of the query or schedule. The action only receives the rendered data file, not the query's filters or
+timezone, so server-side UTC is used for deterministic, predictable partitioning.
+
+## Writing to a bucket in another project
+
+By default the **Bucket** dropdown lists buckets visible to the service account in its configured
+project, which requires the project-level `storage.buckets.list` permission. To deliver to a bucket
+in a different project (for example, a partner's bucket) you usually only have object-level access on
+that single bucket and cannot list the project's buckets.
+
+For this case, leave the **Bucket** dropdown blank and enter the exact bucket name in the
+**Bucket name (manual override)** field. The manual override takes precedence over the dropdown, and
+delivery only requires `storage.objects.create` (e.g. the `roles/storage.objectCreator` role) on the
+target bucket — no project-level listing permission is needed.

--- a/src/actions/google/gcs/google_cloud_storage.ts
+++ b/src/actions/google/gcs/google_cloud_storage.ts
@@ -63,17 +63,23 @@ export class GoogleCloudStorageAction extends Hub.Action {
 
     let filename = request.formParams.filename || request.suggestedFilename()
 
-    // Substitute UTC date tokens ({YYYYMMDD}, {YYYY}, {MM}, {DD}) anywhere in the filename. Since
-    // GCS object names may contain "/", this enables date-partitioned "folders". Done before the
-    // Overwrite timestamp logic below so a token-based name can still be made unique.
+    // Substitute UTC date/time tokens anywhere in the filename. Tokens are case-sensitive:
+    // {MM} is month while {mm} is minutes (moment.js convention). Since GCS object names may
+    // contain "/", this enables date-partitioned "folders". Done before the Overwrite timestamp
+    // logic below so a token-based name can still be made unique.
     const now = new Date()
     const tokens: { [k: string]: string } = {
       YYYY: `${now.getUTCFullYear()}`,
+      YY: `${now.getUTCFullYear()}`.slice(-2),
       MM: String(now.getUTCMonth() + 1).padStart(2, "0"),
       DD: String(now.getUTCDate()).padStart(2, "0"),
+      HH: String(now.getUTCHours()).padStart(2, "0"),
+      mm: String(now.getUTCMinutes()).padStart(2, "0"),
+      ss: String(now.getUTCSeconds()).padStart(2, "0"),
     }
     tokens.YYYYMMDD = tokens.YYYY + tokens.MM + tokens.DD
-    filename = filename.replace(/\{(YYYYMMDD|YYYY|MM|DD)\}/g, (_m: string, t: string) => tokens[t])
+    filename = filename.replace(
+      /\{(YYYYMMDD|YYYY|YY|MM|DD|HH|mm|ss)\}/g, (_m: string, t: string) => tokens[t])
 
     // If the overwrite formParam exists and it is "no" - ensure a timestamp is appended
     if (request.formParams.overwrite && request.formParams.overwrite === "no") {
@@ -191,7 +197,9 @@ export class GoogleCloudStorageAction extends Hub.Action {
       label: "Filename",
       name: "filename",
       type: "string",
-      description: "Optional. Supports UTC date tokens: {YYYYMMDD}, {YYYY}, {MM}, {DD}." +
+      description: "Optional. Supports UTC tokens, combinable with any separators:" +
+        " {YYYYMMDD}, {YYYY}, {YY}, {MM} (month), {DD}, {HH}, {mm} (minutes), {ss}." +
+        " Note {MM} is month and {mm} is minutes (case-sensitive)." +
         " GCS object names may contain \"/\", so you can date-partition into folders," +
         " e.g. \"daily/report_{YYYYMMDD}.csv\" becomes \"daily/report_20260617.csv\".",
     }, {

--- a/src/actions/google/gcs/google_cloud_storage.ts
+++ b/src/actions/google/gcs/google_cloud_storage.ts
@@ -45,7 +45,7 @@ export class GoogleCloudStorageAction extends Hub.Action {
     // The manual override takes precedence over the bucket selected from the dropdown. This allows
     // writing to a bucket in another project (e.g. a partner bucket) where the service account only
     // has object-level access (storage.objects.create) and cannot list buckets at the project level.
-    const bucket = request.formParams.bucket_override || request.formParams.bucket
+    const bucket = request.formParams.bucket_override?.trim() || request.formParams.bucket
 
     if (!bucket) {
       const error: Error = errorWith(

--- a/src/actions/google/gcs/google_cloud_storage.ts
+++ b/src/actions/google/gcs/google_cloud_storage.ts
@@ -42,7 +42,12 @@ export class GoogleCloudStorageAction extends Hub.Action {
   async execute(request: Hub.ActionRequest) {
     const response = new Hub.ActionResponse()
 
-    if (!request.formParams.bucket) {
+    // The manual override takes precedence over the bucket selected from the dropdown. This allows
+    // writing to a bucket in another project (e.g. a partner bucket) where the service account only
+    // has object-level access (storage.objects.create) and cannot list buckets at the project level.
+    const bucket = request.formParams.bucket_override || request.formParams.bucket
+
+    if (!bucket) {
       const error: Error = errorWith(
         HTTP_ERROR.bad_request,
         `${LOG_PREFIX} needs a GCS bucket specified.`,
@@ -57,6 +62,18 @@ export class GoogleCloudStorageAction extends Hub.Action {
     }
 
     let filename = request.formParams.filename || request.suggestedFilename()
+
+    // Substitute UTC date tokens ({YYYYMMDD}, {YYYY}, {MM}, {DD}) anywhere in the filename. Since
+    // GCS object names may contain "/", this enables date-partitioned "folders". Done before the
+    // Overwrite timestamp logic below so a token-based name can still be made unique.
+    const now = new Date()
+    const tokens: { [k: string]: string } = {
+      YYYY: `${now.getUTCFullYear()}`,
+      MM: String(now.getUTCMonth() + 1).padStart(2, "0"),
+      DD: String(now.getUTCDate()).padStart(2, "0"),
+    }
+    tokens.YYYYMMDD = tokens.YYYY + tokens.MM + tokens.DD
+    filename = filename.replace(/\{(YYYYMMDD|YYYY|MM|DD)\}/g, (_m: string, t: string) => tokens[t])
 
     // If the overwrite formParam exists and it is "no" - ensure a timestamp is appended
     if (request.formParams.overwrite && request.formParams.overwrite === "no") {
@@ -83,7 +100,7 @@ export class GoogleCloudStorageAction extends Hub.Action {
     }
 
     const gcs = this.gcsClientFromRequest(request)
-    const file = gcs.bucket(request.formParams.bucket)
+    const file = gcs.bucket(bucket)
       .file(filename)
     const writeStream = file.createWriteStream({
       metadata: {
@@ -132,42 +149,51 @@ export class GoogleCloudStorageAction extends Hub.Action {
     const gcs = this.gcsClientFromRequest(request)
     let results: any
 
+    // Listing buckets requires storage.buckets.list at the PROJECT level, which a service account
+    // delivering to a third-party/cross-project bucket may not have. Treat a listing failure (or an
+    // empty list) as non-fatal: render the form with an empty dropdown so the user can still type a
+    // bucket name into the manual override field below.
     try {
       results = await gcs.getBuckets()
     } catch (e: any) {
-      form.error = `An error occurred while fetching the bucket list.
-
-      Your Google Cloud Storage credentials may be incorrect.
-
-      Google SDK Error: "${e.message}"`
-      winston.error(
-        `${LOG_PREFIX} An error occurred while fetching the bucket list. Google SDK Error: ${e.message} `,
+      winston.warn(
+        `${LOG_PREFIX} Could not list buckets; rendering form with manual bucket entry only.` +
+        ` Google SDK Error: ${e.message}`,
         {webhookId: request.webhookId},
       )
-      return form
     }
 
-    if (!(results && results[0] && results[0][0])) {
-      form.error = "No buckets in account."
-      winston.error(`${LOG_PREFIX} No buckets in account`, {webhookId: request.webhookId})
-      return form
-    }
+    const buckets = (results && results[0]) ? results[0] : []
 
-    const buckets = results[0]
-
-    form.fields = [{
+    const bucketField: any = {
       label: "Bucket",
       name: "bucket",
-      required: true,
+      required: false,
       options: buckets.map((b: any) => {
           return {name: b.id, label: b.name}
         }),
       type: "select",
-      default: buckets[0].id,
+      description: "Buckets visible to the service account in its configured project." +
+        " Leave blank and use the manual override below to write to a bucket in another project.",
+    }
+    if (buckets.length > 0) {
+      bucketField.default = buckets[0].id
+    }
+
+    form.fields = [bucketField, {
+      label: "Bucket name (manual override)",
+      name: "bucket_override",
+      type: "string",
+      description: "Optional. Exact GCS bucket name to write to; takes precedence over the dropdown." +
+        " Use this for cross-project delivery where the service account only has" +
+        " storage.objects.create on the target bucket and cannot list buckets.",
     }, {
       label: "Filename",
       name: "filename",
       type: "string",
+      description: "Optional. Supports UTC date tokens: {YYYYMMDD}, {YYYY}, {MM}, {DD}." +
+        " GCS object names may contain \"/\", so you can date-partition into folders," +
+        " e.g. \"daily/report_{YYYYMMDD}.csv\" becomes \"daily/report_20260617.csv\".",
     }, {
       label: "Overwrite",
       name: "overwrite",

--- a/src/actions/google/gcs/test_google_cloud_storage.ts
+++ b/src/actions/google/gcs/test_google_cloud_storage.ts
@@ -69,7 +69,9 @@ function expectGoogleCloudStorageMatch(request: Hub.ActionRequest,
   // so stubbing it again would throw. Such callers pass stubNow = false.
   const stubDate = stubNow ? sinon.stub(Date, "now").callsFake(() => 1234) : undefined
   return chai.expect(action.validateAndExecute(request)).to.be.fulfilled.then(() => {
-    chai.expect(bucketSpy).to.have.been.calledWithMatch(bucketMatch)
+    // Exact match (not calledWithMatch, which does substring matching for strings) so that
+    // whitespace-trimming assertions on the bucket name are meaningful.
+    chai.expect(bucketSpy).to.have.been.calledWith(bucketMatch)
     chai.expect(fileSpy).to.have.been.calledWithMatch(fileMatch)
     stubClient.restore()
     stubSuggestedFilename.restore()
@@ -427,6 +429,46 @@ describe(`${action.constructor.name} unit tests`, () => {
       request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
       return expectGoogleCloudStorageMatch(request,
         "partner-bucket",
+        "mywackyfilename",
+        Buffer.from("1,2,3,4", "utf8"))
+    })
+
+    it("trims whitespace from the bucket_override value", () => {
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "listedbucket",
+        bucket_override: "  partner-bucket\n",
+        filename: "mywackyfilename",
+      }
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+        "partner-bucket",
+        "mywackyfilename",
+        Buffer.from("1,2,3,4", "utf8"))
+    })
+
+    it("falls back to the dropdown bucket when bucket_override is only whitespace", () => {
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "listedbucket",
+        bucket_override: "   ",
+        filename: "mywackyfilename",
+      }
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+        "listedbucket",
         "mywackyfilename",
         Buffer.from("1,2,3,4", "utf8"))
     })

--- a/src/actions/google/gcs/test_google_cloud_storage.ts
+++ b/src/actions/google/gcs/test_google_cloud_storage.ts
@@ -22,7 +22,9 @@ const FILENAME_FIELD = {
   label: "Filename",
   name: "filename",
   type: "string",
-  description: "Optional. Supports UTC date tokens: {YYYYMMDD}, {YYYY}, {MM}, {DD}." +
+  description: "Optional. Supports UTC tokens, combinable with any separators:" +
+    " {YYYYMMDD}, {YYYY}, {YY}, {MM} (month), {DD}, {HH}, {mm} (minutes), {ss}." +
+    " Note {MM} is month and {mm} is minutes (case-sensitive)." +
     " GCS object names may contain \"/\", so you can date-partition into folders," +
     " e.g. \"daily/report_{YYYYMMDD}.csv\" becomes \"daily/report_20260617.csv\".",
 }
@@ -298,6 +300,69 @@ describe(`${action.constructor.name} unit tests`, () => {
       return expectGoogleCloudStorageMatch(request,
         "mybucket",
         "daily/2026/06/report_17.csv",
+        Buffer.from("1,2,3,4", "utf8"),
+        false).then(() => clock.restore())
+    })
+
+    it("substitutes the 2-digit {YY} year token combined with other tokens", () => {
+      const clock = sinon.useFakeTimers({ now: Date.UTC(2026, 5, 17), toFake: ["Date"] })
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "mybucket",
+        filename: "report_{MM}-{DD}-{YY}.csv",
+      }
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+        "mybucket",
+        "report_06-17-26.csv",
+        Buffer.from("1,2,3,4", "utf8"),
+        false).then(() => clock.restore())
+    })
+
+    it("substitutes UTC time tokens {HH}, {mm}, {ss} alongside date tokens", () => {
+      const clock = sinon.useFakeTimers({ now: Date.UTC(2026, 5, 17, 8, 30, 45), toFake: ["Date"] })
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "mybucket",
+        filename: "report_{YYYYMMDD}T{HH}{mm}{ss}.csv",
+      }
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+        "mybucket",
+        "report_20260617T083045.csv",
+        Buffer.from("1,2,3,4", "utf8"),
+        false).then(() => clock.restore())
+    })
+
+    it("distinguishes {MM} month from {mm} minutes (case-sensitive)", () => {
+      const clock = sinon.useFakeTimers({ now: Date.UTC(2026, 5, 17, 8, 30, 45), toFake: ["Date"] })
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "mybucket",
+        filename: "{MM}_vs_{mm}.csv",
+      }
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+        "mybucket",
+        "06_vs_30.csv",
         Buffer.from("1,2,3,4", "utf8"),
         false).then(() => clock.restore())
     })

--- a/src/actions/google/gcs/test_google_cloud_storage.ts
+++ b/src/actions/google/gcs/test_google_cloud_storage.ts
@@ -8,10 +8,38 @@ import { GoogleCloudStorageAction } from "./google_cloud_storage"
 
 const action = new GoogleCloudStorageAction()
 
+const BUCKET_FIELD_DESCRIPTION = "Buckets visible to the service account in its configured project." +
+  " Leave blank and use the manual override below to write to a bucket in another project."
+const BUCKET_OVERRIDE_FIELD = {
+  label: "Bucket name (manual override)",
+  name: "bucket_override",
+  type: "string",
+  description: "Optional. Exact GCS bucket name to write to; takes precedence over the dropdown." +
+    " Use this for cross-project delivery where the service account only has" +
+    " storage.objects.create on the target bucket and cannot list buckets.",
+}
+const FILENAME_FIELD = {
+  label: "Filename",
+  name: "filename",
+  type: "string",
+  description: "Optional. Supports UTC date tokens: {YYYYMMDD}, {YYYY}, {MM}, {DD}." +
+    " GCS object names may contain \"/\", so you can date-partition into folders," +
+    " e.g. \"daily/report_{YYYYMMDD}.csv\" becomes \"daily/report_20260617.csv\".",
+}
+const OVERWRITE_FIELD = {
+  label: "Overwrite",
+  name: "overwrite",
+  options: [{label: "Yes", name: "yes"}, {label: "No", name: "no"}],
+  default: "yes",
+  description: "If Overwrite is enabled, will use the title or filename and overwrite existing data." +
+    " If disabled, a date time will be appended to the name to make the file unique.",
+}
+
 function expectGoogleCloudStorageMatch(request: Hub.ActionRequest,
                                        bucketMatch: string,
                                        fileMatch: string,
-                                       fileSaveMatch: Buffer) {
+                                       fileSaveMatch: Buffer,
+                                       stubNow = true) {
 
   const createWriteStreamSpy = sinon.spy(async () => {
     let data = Buffer.from("")
@@ -35,14 +63,17 @@ function expectGoogleCloudStorageMatch(request: Hub.ActionRequest,
 
   const stubSuggestedFilename = sinon.stub(request as any, "suggestedFilename")
     .callsFake(() => "stubSuggestedFilename")
-  const stubDate = sinon.stub(Date, "now")
-    .callsFake(() => 1234)
+  // When the caller has installed fake timers (sinon.useFakeTimers), Date.now is already replaced,
+  // so stubbing it again would throw. Such callers pass stubNow = false.
+  const stubDate = stubNow ? sinon.stub(Date, "now").callsFake(() => 1234) : undefined
   return chai.expect(action.validateAndExecute(request)).to.be.fulfilled.then(() => {
     chai.expect(bucketSpy).to.have.been.calledWithMatch(bucketMatch)
     chai.expect(fileSpy).to.have.been.calledWithMatch(fileMatch)
     stubClient.restore()
     stubSuggestedFilename.restore()
-    stubDate.restore()
+    if (stubDate) {
+      stubDate.restore()
+    }
   })
 }
 
@@ -228,6 +259,112 @@ describe(`${action.constructor.name} unit tests`, () => {
           "mywackyfilename.carl_1234.csv",
           Buffer.from("1,2,3,4", "utf8"))
     })
+
+    it("substitutes the {YYYYMMDD} date token in the filename", () => {
+      const clock = sinon.useFakeTimers({ now: Date.UTC(2026, 5, 17), toFake: ["Date"] })
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "mybucket",
+        filename: "report_{YYYYMMDD}.csv",
+      }
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+        "mybucket",
+        "report_20260617.csv",
+        Buffer.from("1,2,3,4", "utf8"),
+        false).then(() => clock.restore())
+    })
+
+    it("substitutes date tokens combined with path segments into a folder key", () => {
+      const clock = sinon.useFakeTimers({ now: Date.UTC(2026, 5, 17), toFake: ["Date"] })
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "mybucket",
+        filename: "daily/{YYYY}/{MM}/report_{DD}.csv",
+      }
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+        "mybucket",
+        "daily/2026/06/report_17.csv",
+        Buffer.from("1,2,3,4", "utf8"),
+        false).then(() => clock.restore())
+    })
+
+    it("leaves a filename with no date tokens unchanged", () => {
+      const clock = sinon.useFakeTimers({ now: Date.UTC(2026, 5, 17), toFake: ["Date"] })
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "mybucket",
+        filename: "plain_report.csv",
+        overwrite: "yes",
+      }
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+        "mybucket",
+        "plain_report.csv",
+        Buffer.from("1,2,3,4", "utf8"),
+        false).then(() => clock.restore())
+    })
+
+    it("substitutes date tokens before appending the overwrite timestamp", () => {
+      const clock = sinon.useFakeTimers({ now: Date.UTC(2026, 5, 17), toFake: ["Date"] })
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "mybucket",
+        filename: "report_{YYYYMMDD}.csv",
+        overwrite: "no",
+      }
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+        "mybucket",
+        `report_20260617_${Date.UTC(2026, 5, 17)}.csv`,
+        Buffer.from("1,2,3,4", "utf8"),
+        false).then(() => clock.restore())
+    })
+
+    it("uses the bucket_override value in preference to the dropdown bucket", () => {
+      const request = new Hub.ActionRequest()
+      request.type = Hub.ActionType.Dashboard
+      request.params = {
+        client_email: "myemail",
+        private_key: "mykey",
+        project_id: "myproject",
+      }
+      request.formParams = {
+        bucket: "listedbucket",
+        bucket_override: "partner-bucket",
+        filename: "mywackyfilename",
+      }
+      request.attachment = {dataBuffer: Buffer.from("1,2,3,4", "utf8")}
+      return expectGoogleCloudStorageMatch(request,
+        "partner-bucket",
+        "mywackyfilename",
+        Buffer.from("1,2,3,4", "utf8"))
+    })
   })
 
   describe("form", () => {
@@ -257,29 +394,23 @@ describe(`${action.constructor.name} unit tests`, () => {
         fields: [{
           label: "Bucket",
           name: "bucket",
-          required: true,
+          required: false,
           options: [
             {name: "1", label: "A"},
             {name: "2", label: "B"},
           ],
           type: "select",
+          description: BUCKET_FIELD_DESCRIPTION,
           default: "1",
-        }, {
-          label: "Filename",
-          name: "filename",
-          type: "string",
-        }, {
-          label: "Overwrite",
-          name: "overwrite",
-          options: [{label: "Yes", name: "yes"}, {label: "No", name: "no"}],
-          default: "yes",
-          description: "If Overwrite is enabled, will use the title or filename and overwrite existing data." +
-            " If disabled, a date time will be appended to the name to make the file unique.",
-        }],
+        },
+          BUCKET_OVERRIDE_FIELD,
+          FILENAME_FIELD,
+          OVERWRITE_FIELD,
+        ],
       }).and.notify(stubClient.restore).and.notify(done)
     })
 
-    it("has friendly error with no buckets", (done) => {
+    it("renders form with manual override when no buckets are listed", (done) => {
 
       const stubClient = sinon.stub(action as any, "gcsClientFromRequest")
         .callsFake(() => ({
@@ -293,15 +424,25 @@ describe(`${action.constructor.name} unit tests`, () => {
         project_id: "foo",
       }
       const form = action.validateAndFetchForm(request)
-      chai.expect(form).to.eventually
-        .deep.eq({error: "No buckets in account.", fields: []})
-        .and.notify(stubClient.restore)
-        .and.notify(done)
+      chai.expect(form).to.eventually.deep.equal({
+        fields: [{
+          label: "Bucket",
+          name: "bucket",
+          required: false,
+          options: [],
+          type: "select",
+          description: BUCKET_FIELD_DESCRIPTION,
+        },
+          BUCKET_OVERRIDE_FIELD,
+          FILENAME_FIELD,
+          OVERWRITE_FIELD,
+        ],
+      }).and.notify(stubClient.restore).and.notify(done)
     })
 
   })
 
-  it("has a friendly error when SDK chokes", (done) => {
+  it("renders form with manual override when listing buckets fails", (done) => {
 
     const stubClient = sinon.stub(action as any, "gcsClientFromRequest")
       .callsFake(() => ({
@@ -315,14 +456,20 @@ describe(`${action.constructor.name} unit tests`, () => {
       project_id: "foo",
     }
     const form = action.validateAndFetchForm(request)
-    chai.expect(form).to.eventually
-      .deep.eq({error: `An error occurred while fetching the bucket list.
-
-      Your Google Cloud Storage credentials may be incorrect.
-
-      Google SDK Error: "something weird from your friends at google"`, fields: []})
-      .and.notify(stubClient.restore)
-      .and.notify(done)
+    chai.expect(form).to.eventually.deep.equal({
+      fields: [{
+        label: "Bucket",
+        name: "bucket",
+        required: false,
+        options: [],
+        type: "select",
+        description: BUCKET_FIELD_DESCRIPTION,
+      },
+        BUCKET_OVERRIDE_FIELD,
+        FILENAME_FIELD,
+        OVERWRITE_FIELD,
+      ],
+    }).and.notify(stubClient.restore).and.notify(done)
   })
 
 })


### PR DESCRIPTION
## Summary

Two backward-compatible enhancements to the **Google Cloud Storage** action.

### 1. Filename date/time tokens

The destination object name now supports UTC tokens that are substituted at delivery time, **before** the existing Overwrite uniqueness timestamp. Each token is replaced independently wherever it appears, so any format can be composed with your own separators. Because GCS object names may contain `/`, this also enables date-/time-partitioned "folders" with no extra field.

| Token | Meaning | Example (`2026-06-17 08:30:45Z`) |
|---|---|---|
| `{YYYYMMDD}` | year+month+day composite | `20260617` |
| `{YYYY}` | 4-digit year | `2026` |
| `{YY}` | 2-digit year | `26` |
| `{MM}` | **month** | `06` |
| `{DD}` | day of month | `17` |
| `{HH}` | hour, 24-hour | `08` |
| `{mm}` | **minutes** | `30` |
| `{ss}` | seconds | `45` |

> Tokens are **case-sensitive** (moment.js convention): `{MM}` is month, `{mm}` is minutes. `{YYYYMMDD}` is a convenience for `{YYYY}{MM}{DD}`.

**Before / after**

```
report_{YYYYMMDD}.csv               ->  report_20260617.csv
{YYYY}-{MM}-{DD}.csv                ->  2026-06-17.csv
daily/{YYYY}/{MM}/report.csv        ->  gs://<bucket>/daily/2026/06/report.csv
hourly/{YYYYMMDD}T{HH}{mm}{ss}.csv  ->  gs://<bucket>/hourly/20260617T083045.csv
```

Implemented with the built-in `Date` — **no new npm dependencies** (no moment/dayjs).

### 2. Manual bucket override (cross-project / third-party delivery)

The **Bucket** dropdown is populated by `gcs.getBuckets()`, which requires the **project-level** `storage.buckets.list` permission. Delivering a scheduled Look to a partner's bucket in *their* GCP project shouldn't require granting project-level IAM to your service account — partners will (correctly) only grant `roles/storage.objectCreator` on the single target bucket.

This PR:
- makes `getBuckets()` **non-fatal** — if listing fails (or returns nothing), the form renders with an empty dropdown instead of erroring;
- adds an optional **"Bucket name (manual override)"** field (`bucket_override`) that takes precedence over the dropdown.

`execute()` then only needs `storage.objects.create` on the target bucket.

## Backward compatibility

- Filenames with **no tokens are unchanged**.
- The `Overwrite = "No"` `Date.now()` uniqueness suffix is **intact** (tokens are substituted first).
- Existing `formParams.bucket` (dropdown) behavior is **unchanged** when no override is supplied.

## Design note: time zone

Tokens resolve against the action hub server's **UTC clock**, not the query/schedule timezone. The action only receives the rendered data file, not the query's filters or timezone, so server-side UTC is used for deterministic, predictable partitioning. This is documented in the action README and called out here in case maintainers prefer a different stance.

## Testing

`yarn test` (mocha + `tsc --noEmit` + tslint) passes clean for this action: typecheck ✅, lint ✅, and all GCS tests pass. New/updated tests cover `{YYYYMMDD}` resolution, tokens combined with path segments, `{YY}`, the `{HH}`/`{mm}`/`{ss}` time tokens, the `{MM}`-vs-`{mm}` case-sensitivity distinction, the no-token regression, token-before-timestamp ordering, `bucket_override` precedence, and the non-fatal bucket-listing form behavior.

## Docs

Token syntax and the manual bucket override are documented in the **Filename** form-field description and in `src/actions/google/gcs/README.md`.

## CLA

This is a Google-owned repository and requires a signed [Contributor License Agreement](https://cla.developers.google.com/) before it can be merged. The contributor will sign the CLA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
